### PR TITLE
chore: run tests in matrix to completion

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -4,6 +4,7 @@ jobs:
   integration:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         kong_image:
         - 'kong:2.3.3'

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -4,6 +4,7 @@ jobs:
   unit-test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         database:
         - sqlite3


### PR DESCRIPTION
fail-fast is set to true by default. This results in Github Action
stopping/killing all other tests in the matrix.
This patch sets the value to false to ensure all tests are run.