### PR TITLE
fix: enforce additionalProperties in schemas

### DIFF
--- a/internal/gen/jsonschema/schemas/node.json
+++ b/internal/gen/jsonschema/schemas/node.json
@@ -7,6 +7,12 @@
     "version"
   ],
   "properties": {
+    "config_hash": {
+      "maxLength": 32,
+      "minLength": 32,
+      "pattern": "[a-z0-9]{32}",
+      "type": "string"
+    },
     "created_at": {
       "minimum": 1,
       "type": "integer"
@@ -41,5 +47,6 @@
       "type": "string"
     }
   },
+  "additionalProperties": false,
   "type": "object"
 }

--- a/internal/gen/jsonschema/schemas/plugin.json
+++ b/internal/gen/jsonschema/schemas/plugin.json
@@ -41,6 +41,28 @@
       },
       "type": "array"
     },
+    "route": {
+      "properties": {
+        "id": {
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+          "type": "string",
+          "description": "must be a valid UUID"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "service": {
+      "properties": {
+        "id": {
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+          "type": "string",
+          "description": "must be a valid UUID"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
     "tags": {
       "items": {
         "maxLength": 128,
@@ -56,5 +78,6 @@
       "type": "integer"
     }
   },
+  "additionalProperties": false,
   "type": "object"
 }

--- a/internal/gen/jsonschema/schemas/route.json
+++ b/internal/gen/jsonschema/schemas/route.json
@@ -67,6 +67,7 @@
           }
         }
       },
+      "additionalProperties": false,
       "type": "object"
     },
     "hosts": {
@@ -191,6 +192,17 @@
     "response_buffering": {
       "type": "boolean"
     },
+    "service": {
+      "properties": {
+        "id": {
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+          "type": "string",
+          "description": "must be a valid UUID"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
     "snis": {
       "items": {
         "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
@@ -257,6 +269,7 @@
       "type": "integer"
     }
   },
+  "additionalProperties": false,
   "type": "object",
   "allOf": [
     {

--- a/internal/gen/jsonschema/schemas/service.json
+++ b/internal/gen/jsonschema/schemas/service.json
@@ -111,6 +111,7 @@
       "type": "integer"
     }
   },
+  "additionalProperties": false,
   "type": "object",
   "allOf": [
     {

--- a/internal/gen/jsonschema/schemas/status.json
+++ b/internal/gen/jsonschema/schemas/status.json
@@ -67,5 +67,6 @@
       "type": "integer"
     }
   },
+  "additionalProperties": false,
   "type": "object"
 }

--- a/internal/model/json/generator/schema.go
+++ b/internal/model/json/generator/schema.go
@@ -45,7 +45,7 @@ type Schema struct {
 	Required             []string           `json:"required,omitempty"`             // section 5.15
 	Properties           map[string]*Schema `json:"properties,omitempty"`           // section 5.16
 	PatternProperties    map[string]*Schema `json:"patternProperties,omitempty"`    // section 5.17
-	AdditionalProperties bool               `json:"additionalProperties,omitempty"` // section 5.18
+	AdditionalProperties *bool              `json:"additionalProperties,omitempty"` // section 5.18
 	Dependencies         map[string]*Schema `json:"dependencies,omitempty"`         // section 5.19
 	Enum                 []interface{}      `json:"enum,omitempty"`                 // section 5.20
 	Type                 string             `json:"type,omitempty"`                 // section 5.21

--- a/internal/model/json/validation/translator.go
+++ b/internal/model/json/validation/translator.go
@@ -127,6 +127,10 @@ func (t ErrorTranslator) getErr(schemaErr jsonschema.Detailed,
 			fallthrough
 		case "maxItems":
 			fallthrough
+		case "additionalProperties":
+			fallthrough
+		case "minLength":
+			fallthrough
 		case "maxLength":
 			message = schemaErr.Error
 		default:

--- a/internal/model/json/validation/typedefs/fields.go
+++ b/internal/model/json/validation/typedefs/fields.go
@@ -18,6 +18,16 @@ var ID = &generator.Schema{
 	Pattern:     "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
 }
 
+var falsy = false
+
+var ReferenceObject = &generator.Schema{
+	Type: "object",
+	Properties: map[string]*generator.Schema{
+		"id": ID,
+	},
+	AdditionalProperties: &falsy,
+}
+
 var Name = &generator.Schema{
 	Type:      "string",
 	Pattern:   namePattern,

--- a/internal/resource/node.go
+++ b/internal/resource/node.go
@@ -13,10 +13,17 @@ import (
 const (
 	maxVersionLength  = 128
 	maxHostnameLength = 1024
+	hashLength        = 32
+	hashPattern       = "[a-z0-9]{32}"
 
 	TypeNode = model.Type("node")
 
 	NodeTypeKongProxy = "kong-proxy"
+)
+
+var (
+	truthy = true
+	falsy  = false
 )
 
 func NewNode() Node {
@@ -87,6 +94,12 @@ func init() {
 				Type:    "integer",
 				Minimum: 1,
 			},
+			"config_hash": {
+				Type:      "string",
+				MinLength: hashLength,
+				MaxLength: hashLength,
+				Pattern:   hashPattern,
+			},
 			"version": {
 				Type:      "string",
 				MinLength: 1,
@@ -95,7 +108,7 @@ func init() {
 			"created_at": typedefs.UnixEpoch,
 			"updated_at": typedefs.UnixEpoch,
 		},
-		AdditionalProperties: false,
+		AdditionalProperties: &falsy,
 		Required: []string{
 			"id",
 			"hostname",

--- a/internal/resource/plugin.go
+++ b/internal/resource/plugin.go
@@ -128,10 +128,12 @@ func init() {
 			},
 			"config": {
 				Type:                 "object",
-				AdditionalProperties: true,
+				AdditionalProperties: &truthy,
 			},
+			"service": typedefs.ReferenceObject,
+			"route":   typedefs.ReferenceObject,
 		},
-		AdditionalProperties: false,
+		AdditionalProperties: &falsy,
 		Required: []string{
 			"name",
 		},

--- a/internal/resource/route.go
+++ b/internal/resource/route.go
@@ -167,7 +167,7 @@ func init() {
 			},
 			"headers": {
 				Type:                 "object",
-				AdditionalProperties: false,
+				AdditionalProperties: &falsy,
 				PatternProperties: map[string]*generator.Schema{
 					"^[Hh][Oo][Ss][Tt]$": {
 						Not: &generator.Schema{
@@ -236,8 +236,9 @@ func init() {
 			"tags":       typedefs.Tags,
 			"created_at": typedefs.UnixEpoch,
 			"updated_at": typedefs.UnixEpoch,
+			"service":    typedefs.ReferenceObject,
 		},
-		AdditionalProperties: false,
+		AdditionalProperties: &falsy,
 		Required: []string{
 			"id",
 			"protocols",

--- a/internal/resource/service.go
+++ b/internal/resource/service.go
@@ -126,7 +126,7 @@ func init() {
 			"created_at": typedefs.UnixEpoch,
 			"updated_at": typedefs.UnixEpoch,
 		},
-		AdditionalProperties: false,
+		AdditionalProperties: &falsy,
 		Required: []string{
 			"id",
 			"protocol",

--- a/internal/resource/status.go
+++ b/internal/resource/status.go
@@ -128,7 +128,7 @@ func init() {
 			"created_at": typedefs.UnixEpoch,
 			"updated_at": typedefs.UnixEpoch,
 		},
-		AdditionalProperties: false,
+		AdditionalProperties: &falsy,
 		Required: []string{
 			"id",
 			"context_reference",

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -94,7 +94,8 @@ func TestCreate(t *testing.T) {
 				Id: sid,
 			},
 		}
-		require.Nil(t, s.Create(ctx, route))
+		err = s.Create(ctx, route)
+		require.Nil(t, err)
 	})
 	t.Run("creating an object with invalid foreign reference fails", func(t *testing.T) {
 		route := resource.NewRoute()


### PR DESCRIPTION
Commit 2eedc90 highlights a problem: fields can be introduced via
protobuf without corresponding work in JSON schemas.
Upon investigation, this turns out to be a much more serious issue.
Validation for 'additionalProperties: false' is not actually working.
This is because of zero value for 'bool' is 'false' and 'omitempty' is
set for the field.

This patch fixes the problem with the code generator and contains fixes
for all schemas where 'additionalProperties' was being violated.

The fix should also ensure that the same mistake doesn't happen again in
the future.