### PR TITLE
tests: reduce flakiness by waiting for routines to finish

### DIFF
--- a/internal/test/kong/run.go
+++ b/internal/test/kong/run.go
@@ -149,7 +149,7 @@ func RunDP(ctx context.Context, input DockerInput) error {
 	go func() {
 		defer wg.Done()
 		<-ctx.Done()
-		_ = cmd.Process.Signal(os.Interrupt)
+		_ = cmd.Process.Signal(os.Kill)
 	}()
 
 	err = cmd.Wait()

--- a/internal/test/run/run.go
+++ b/internal/test/run/run.go
@@ -1,0 +1,40 @@
+package run
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/kong/koko/internal/cmd"
+	"github.com/kong/koko/internal/test/kong"
+	"github.com/stretchr/testify/require"
+)
+
+func Koko(t *testing.T, serverConfig cmd.ServerConfig) func() {
+	var wg sync.WaitGroup
+	ctx, cancel := context.WithCancel(context.Background())
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		err := cmd.Run(ctx, serverConfig)
+		require.Nil(t, err)
+	}()
+	return func() {
+		cancel()
+		wg.Wait()
+	}
+}
+
+func KongDP(input kong.DockerInput) func() {
+	var wg sync.WaitGroup
+	ctx, cancel := context.WithCancel(context.Background())
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_ = kong.RunDP(ctx, input)
+	}()
+	return func() {
+		cancel()
+		wg.Wait()
+	}
+}


### PR DESCRIPTION
- Send SIGKILL instead of SIGINT to Kong DP
- Wait for servers to shut down before starting a new test