### PR TITLE
tests: load plugin schemas once for entire package

### DIFF
--- a/internal/server/admin/helpers_test.go
+++ b/internal/server/admin/helpers_test.go
@@ -13,6 +13,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var validator plugin.Validator
+
+func init() {
+	luaValidator, err := plugin.NewLuaValidator(plugin.Opts{Logger: log.Logger})
+	if err != nil {
+		panic(err)
+	}
+	err = luaValidator.LoadSchemasFromEmbed(plugin.Schemas, "schemas")
+	if err != nil {
+		panic(err)
+	}
+	validator = luaValidator
+	resource.SetValidator(validator)
+}
+
 func setup(t *testing.T) (*httptest.Server, func()) {
 	p, err := util.GetPersister()
 	require.Nil(t, err)
@@ -22,14 +37,6 @@ func setup(t *testing.T) (*httptest.Server, func()) {
 }
 
 func setupWithDB(t *testing.T, store store.Store) (*httptest.Server, func()) {
-	validator, err := plugin.NewLuaValidator(plugin.Opts{Logger: log.Logger})
-	require.Nil(t, err)
-	err = validator.LoadSchemasFromEmbed(plugin.Schemas, "schemas")
-	if err != nil {
-		panic(err)
-	}
-	resource.SetValidator(validator)
-
 	handler, err := NewHandler(HandlerOpts{
 		Logger: log.Logger,
 		StoreLoader: serverUtil.DefaultStoreLoader{


### PR DESCRIPTION
Loading plugin schemas is a slow process and is meant to be done at
startup or infrequently during the life of a server. Instantiating
schemas and the validator for each test significantly slows down the
tests.

Speed up with the patch:

before:

ok      github.com/kong/koko/internal/server/admin      89.791s

after:

ok      github.com/kong/koko/internal/server/admin      9.368s