### PR TITLE
fix: close database connections

### DIFF
--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -54,6 +54,7 @@ func Run(ctx context.Context, config ServerConfig) error {
 	if err != nil {
 		return fmt.Errorf("database: %v", err)
 	}
+	defer persister.Close()
 
 	store := store.New(persister, logger.With(zap.String("component",
 		"store"))).ForCluster("default")

--- a/internal/persistence/postgres/postgres.go
+++ b/internal/persistence/postgres/postgres.go
@@ -133,6 +133,10 @@ func (s *Postgres) Tx(ctx context.Context) (persistence.Tx, error) {
 	return &sqliteTx{tx: tx}, nil
 }
 
+func (s *Postgres) Close() error {
+	return s.db.Close()
+}
+
 type sqliteTx struct {
 	tx *sql.Tx
 }

--- a/internal/persistence/sqlite/sqlite.go
+++ b/internal/persistence/sqlite/sqlite.go
@@ -123,6 +123,10 @@ func (s *SQLite) Tx(ctx context.Context) (persistence.Tx, error) {
 	return &sqliteTx{tx: tx}, nil
 }
 
+func (s *SQLite) Close() error {
+	return s.db.Close()
+}
+
 type sqliteTx struct {
 	tx *sql.Tx
 }

--- a/internal/persistence/store.go
+++ b/internal/persistence/store.go
@@ -14,6 +14,7 @@ import (
 type Persister interface {
 	CRUD
 	Tx(context.Context) (Tx, error)
+	Close() error
 }
 
 type CRUD interface {

--- a/internal/server/admin/helpers_test.go
+++ b/internal/server/admin/helpers_test.go
@@ -33,7 +33,11 @@ func setup(t *testing.T) (*httptest.Server, func()) {
 	require.Nil(t, err)
 	objectStore := store.New(p, log.Logger)
 
-	return setupWithDB(t, objectStore.ForCluster("default"))
+	server, cleanup := setupWithDB(t, objectStore.ForCluster("default"))
+	return server, func() {
+		cleanup()
+		p.Close()
+	}
 }
 
 func setupWithDB(t *testing.T, store store.Store) (*httptest.Server, func()) {


### PR DESCRIPTION
Close database connections once the program execution ends.
This also ensures that when tests are run against an external database instance,
connections are not exhausted.