### PR TITLE
tests: parallelize unit test and test-race make target

### DIFF
--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -25,5 +25,6 @@ jobs:
         key: ${{ runner.os }}-go-unit-${{ hashFiles('**/go.sum') }}
     - name: setup-db
       run: ./scripts/setup-db.sh &
-    - name: make test
-      run: make test
+    - name: make test-race
+      run: make test-race
+

--- a/Makefile
+++ b/Makefile
@@ -22,11 +22,14 @@ all: lint test
 
 .PHONY: test
 test:
-	go test -count 1 -p 1 -race ./...
+	go test -count 1 ./...
+
+test-race:
+	go test -count 1 -race ./...
 
 .PHONY: test-integration
 test-integration:
-	go test -tags=integration -race -count 1 -p 1 ./internal/test/...
+	go test -tags=integration -race -count 1 ./internal/test/...
 
 .PHONY: gen
 gen:


### PR DESCRIPTION
* remove -p 1 flag to run tests in parallel across packages
* update test target to stop using race detector, devs are encouraged to
  use this in their development workflows
* introduce a new test-race target to test, this is used in the CI