### PR TITLE
fix: DELETE on SNIs should return 204

### DIFF
--- a/internal/server/admin/sni_service.go
+++ b/internal/server/admin/sni_service.go
@@ -84,6 +84,7 @@ func (s *SNIService) DeleteSNI(ctx context.Context, req *v1.DeleteSNIRequest) (*
 		store.DeleteByType(resource.TypeSNI)); err != nil {
 		return nil, s.err(err)
 	}
+	util.SetHeader(ctx, http.StatusNoContent)
 	return &v1.DeleteSNIResponse{}, nil
 }
 

--- a/internal/server/admin/sni_test.go
+++ b/internal/server/admin/sni_test.go
@@ -183,7 +183,7 @@ func TestSNIDelete(t *testing.T) {
 	}).Expect().Status(http.StatusCreated)
 	sniID := res.JSON().Path("$.item.id").String().Raw()
 	t.Run("deleting an existing SNI succeeds", func(t *testing.T) {
-		c.DELETE("/v1/snis/{id}", sniID).Expect().Status(http.StatusOK)
+		c.DELETE("/v1/snis/{id}", sniID).Expect().Status(http.StatusNoContent)
 	})
 	t.Run("deleting a non-existent SNI fails", func(t *testing.T) {
 		c.DELETE("/v1/snis/{id}", uuid.NewString()).Expect().Status(http.StatusNotFound)


### PR DESCRIPTION
```
$ http delete :8001/snis/13a8d963-5e7a-4e68-909f-00feefbcfb7e
HTTP/1.1 204 No Content
```