### PR TITLE
feat: introduce on-delete cascades for foreign relations

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -302,35 +302,41 @@ func (s *ObjectStore) Delete(ctx context.Context,
 	ctx, cancel := context.WithTimeout(ctx, DefaultDBQueryTimeout)
 	defer cancel()
 	opt := NewDeleteOpts(opts...)
-	object, err := model.NewObject(opt.typ)
+	return s.withTx(ctx, func(tx persistence.Tx) error {
+		return s.delete(ctx, tx, opt.typ, opt.id)
+	})
+}
+
+func (s *ObjectStore) delete(ctx context.Context, tx persistence.Tx,
+	typ model.Type, id string,
+) error {
+	object, err := model.NewObject(typ)
 	if err != nil {
 		return err
 	}
-	return s.withTx(ctx, func(tx persistence.Tx) error {
-		err = s.readByTypeID(ctx, tx, opt.typ, opt.id, object)
-		if err != nil {
-			return err
-		}
+	err = s.readByTypeID(ctx, tx, typ, id, object)
+	if err != nil {
+		return err
+	}
 
-		err = s.checkForeignIndexesForDelete(ctx, tx, object)
-		if err != nil {
-			return err
-		}
+	err = s.onDeleteCascade(ctx, tx, object)
+	if err != nil {
+		return err
+	}
 
-		key, err := s.genID(opt.typ, opt.id)
-		if err != nil {
-			return err
-		}
+	key, err := s.genID(typ, id)
+	if err != nil {
+		return err
+	}
 
-		err = tx.Delete(ctx, key)
-		if err != nil {
-			return err
-		}
-		if err := s.deleteIndexes(ctx, tx, object); err != nil {
-			return err
-		}
-		return s.updateEvent(ctx, tx, object)
-	})
+	err = tx.Delete(ctx, key)
+	if err != nil {
+		return err
+	}
+	if err := s.deleteIndexes(ctx, tx, object); err != nil {
+		return err
+	}
+	return s.updateEvent(ctx, tx, object)
 }
 
 func (s *ObjectStore) List(ctx context.Context, list model.ObjectList, opts ...ListOptsFunc) error {


### PR DESCRIPTION
Up until now, the code errored out if there was a foreign-key relation that
existed on the entity that was being deleted.

With this patch, when the delete operation detects a foreign-key
relation, the related entity is deleted first before deleting the parent
entity. This process is performed recursively - deleting a service
causes the plugins configured on a route related to the service are also
deleted.

This matches up the behavior of DELETE methods in Kong's Admin API with
Koko with one known exception: deleting a ca-certificate resource errors
out when a Service resources references it, koko will instead delete the
Service as well. While not ideal, this is considered acceptable for this patch.