### PR TITLE
fix: reconcile payload in an async thread

### DIFF
--- a/internal/server/kong/ws/manager.go
+++ b/internal/server/kong/ws/manager.go
@@ -203,12 +203,16 @@ func (m *Manager) AddNode(node Node) {
 				Error("remove node")
 		}
 	}()
-	err = m.reconcileKongPayload(context.Background())
-	if err != nil {
-		m.logger.With(zap.Error(err)).
-			Error("reconcile configuration")
-	}
-	m.broadcast()
+
+	// refresh the payload on DP connect
+	go func() {
+		err = m.reconcileKongPayload(context.Background())
+		if err != nil {
+			m.logger.With(zap.Error(err)).
+				Error("reconcile configuration")
+		}
+		m.broadcast()
+	}()
 }
 
 // broadcast sends the most recent configuration to all connected nodes.


### PR DESCRIPTION
Reconciliation of payload can take relatively long and doing so on the
request thread increases the response latency as perceived by the DP.

This patch ensures that reconciliation takes place but in a separate
thread.