### PR TITLE
fix: correct db_less check which corrects defaults for hybrid

### DIFF
--- a/internal/plugin/schemas/rate-limiting.lua
+++ b/internal/plugin/schemas/rate-limiting.lua
@@ -24,12 +24,8 @@ end
 
 
 local function is_dbless()
-  local _, database, role = pcall(function()
-    return kong.configuration.database,
-           kong.configuration.role
-  end)
-
-  return database == "off" or role == "control_plane"
+  -- Only hybrid mode is available with Koko
+  return true
 end
 
 

--- a/internal/plugin/schemas/response-ratelimiting.lua
+++ b/internal/plugin/schemas/response-ratelimiting.lua
@@ -24,12 +24,8 @@ end
 
 
 local function is_dbless()
-  local _, database, role = pcall(function()
-    return kong.configuration.database,
-           kong.configuration.role
-  end)
-
-  return database == "off" or role == "control_plane"
+  -- Only hybrid mode is available with Koko
+  return true
 end
 
 


### PR DESCRIPTION
Found this issue while testing plugins using minimum required fields. Since Koko operates in hybrid mode only the defaults for these plugins should apply based on that role.