### PR TITLE
fix: correct extra processing function for version compatibility

### DIFF
--- a/internal/server/kong/ws/config/version_compatibility.go
+++ b/internal/server/kong/ws/config/version_compatibility.go
@@ -34,8 +34,8 @@ type VersionCompatibility interface {
 type VersionCompatibilityOpts struct {
 	Logger          *zap.Logger
 	KongCPVersion   string
-	ExtraProcessing func(uncompressedPayload string, controlPlaneVersion uint64, dataPlaneVersion uint64,
-		isEnterprise bool, logger *zap.Logger) (string, error)
+	ExtraProcessing func(uncompressedPayload string, dataPlaneVersion uint64, isEnterprise bool,
+		logger *zap.Logger) (string, error)
 }
 
 type UpdateType uint8
@@ -55,8 +55,8 @@ type WSVersionCompatibility struct {
 	logger             *zap.Logger
 	kongCPVersion      uint64
 	configTableUpdates map[uint64][]ConfigTableUpdates
-	extraProcessing    func(uncompressedPayload string, controlPlaneVersion uint64, dataPlaneVersion uint64,
-		isEnterprise bool, logger *zap.Logger) (string, error)
+	extraProcessing    func(uncompressedPayload string, dataPlaneVersion uint64, isEnterprise bool,
+		logger *zap.Logger) (string, error)
 }
 
 func NewVersionCompatibilityProcessor(opts VersionCompatibilityOpts) (*WSVersionCompatibility, error) {
@@ -123,8 +123,8 @@ func (vc *WSVersionCompatibility) performExtraProcessing(uncompressedPayload str
 	isEnterprise bool,
 ) (string, error) {
 	if vc.extraProcessing != nil {
-		processedPayload, err := vc.extraProcessing(uncompressedPayload, vc.kongCPVersion, dataPlaneVersion,
-			isEnterprise, vc.logger)
+		processedPayload, err := vc.extraProcessing(uncompressedPayload, dataPlaneVersion, isEnterprise,
+			vc.logger)
 		if err != nil {
 			return "", err
 		}

--- a/internal/server/kong/ws/config/version_compatibility_test.go
+++ b/internal/server/kong/ws/config/version_compatibility_test.go
@@ -925,8 +925,8 @@ func TestVersionCompatibility_PerformExtraProcessing(t *testing.T) {
 			wsvc, err := NewVersionCompatibilityProcessor(VersionCompatibilityOpts{
 				Logger:        log.Logger,
 				KongCPVersion: "2.8.0",
-				ExtraProcessing: func(uncompressedPayload string, controlPlaneVersion uint64,
-					dataPlaneVersion uint64, isEnterprise bool, logger *zap.Logger,
+				ExtraProcessing: func(uncompressedPayload string, dataPlaneVersion uint64, isEnterprise bool,
+					logger *zap.Logger,
 				) (string, error) {
 					if test.wantsErr {
 						return "", fmt.Errorf("extra processing error")
@@ -961,8 +961,8 @@ func TestVersionCompatibility_PerformExtraProcessing(t *testing.T) {
 		wsvc, err := NewVersionCompatibilityProcessor(VersionCompatibilityOpts{
 			Logger:        log.Logger,
 			KongCPVersion: "2.8.0",
-			ExtraProcessing: func(uncompressedPayload string, controlPlaneVersion uint64, dataPlaneVersion uint64,
-				isEnterprise bool, logger *zap.Logger,
+			ExtraProcessing: func(uncompressedPayload string, dataPlaneVersion uint64, isEnterprise bool,
+				logger *zap.Logger,
 			) (string, error) {
 				return sjson.Set(uncompressedPayload, "config_table.extra_processing", "processed")
 			},


### PR DESCRIPTION
This function should include the control plane version and the logger in order for proper compatibility checks and for the extra processor to perform logging operations under the `version-compatibility` logger umbrella.