### PR TITLE
feat: add route error handler to detect route failure on request context

### DIFF
--- a/internal/server/admin/handler.go
+++ b/internal/server/admin/handler.go
@@ -160,10 +160,12 @@ func NewHandler(opts HandlerOpts) (http.Handler, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	mux := runtime.NewServeMux(
 		runtime.WithMarshalerOption(runtime.MIMEWildcard, json.Marshaller),
+		runtime.WithErrorHandler(util.ErrorHandler),
 		runtime.WithForwardResponseOption(util.SetHTTPStatus),
-		runtime.WithRoutingErrorHandler(util.RouteErrorHandler),
+		runtime.WithForwardResponseOption(util.FinishTrace),
 	)
 
 	err = v1.RegisterMetaServiceHandlerServer(context.Background(),


### PR DESCRIPTION
This can be used to detect invalid requests for tracing when a handler isn't match in the grpc runtime servemux