### PR TITLE
chore: use buf breaking cmd to detect breaking proto changes

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -24,5 +24,4 @@ jobs:
     - name: make verify
       run: make gen-verify
     - name: make lint
-      run: |
-        make lint
+      run: make lint


### PR DESCRIPTION
chore: use buf breaking cmd to detect breaking proto changes on lint target against main branch

https://docs.buf.build/breaking/usage