### PR TITLE
fix: allow empty "path" for services matching Kong

### DIFF
--- a/internal/gen/jsonschema/schemas/service.json
+++ b/internal/gen/jsonschema/schemas/service.json
@@ -187,31 +187,6 @@
       }
     },
     {
-      "description": "path is required when protocol is http or https",
-      "if": {
-        "required": [
-          "protocol"
-        ],
-        "properties": {
-          "protocol": {
-            "oneOf": [
-              {
-                "const": "https"
-              },
-              {
-                "const": "http"
-              }
-            ]
-          }
-        }
-      },
-      "then": {
-        "required": [
-          "path"
-        ]
-      }
-    },
-    {
       "description": "path can be set only when protocol is 'http' or 'https'",
       "if": {
         "required": [

--- a/internal/resource/helper.go
+++ b/internal/resource/helper.go
@@ -50,13 +50,7 @@ func parseURL(s *v1.Service) error {
 		s.Port = int32(port)
 	}
 	s.Host = host
-
-	// default to '/' if path is not provided
-	path := u.Path
-	if path == "" {
-		path = "/"
-	}
-	s.Path = path
+	s.Path = u.Path
 	return nil
 }
 

--- a/internal/resource/service.go
+++ b/internal/resource/service.go
@@ -212,27 +212,6 @@ func init() {
 				},
 			},
 			{
-				Description: "path is required when protocol is http or https",
-				If: &generator.Schema{
-					Required: []string{"protocol"},
-					Properties: map[string]*generator.Schema{
-						"protocol": {
-							OneOf: []*generator.Schema{
-								{
-									Const: typedefs.ProtocolHTTPS,
-								},
-								{
-									Const: typedefs.ProtocolHTTP,
-								},
-							},
-						},
-					},
-				},
-				Then: &generator.Schema{
-					Required: []string{"path"},
-				},
-			},
-			{
 				Description: "path can be set only when protocol is 'http' or" +
 					" 'https'",
 				If: &generator.Schema{

--- a/internal/resource/service_test.go
+++ b/internal/resource/service_test.go
@@ -147,11 +147,8 @@ func TestService_Validate(t *testing.T) {
 			wantErr: true,
 			Errs: []*model.ErrorDetail{
 				{
-					Type: model.ErrorType_ERROR_TYPE_ENTITY,
-					Messages: []string{
-						"missing properties: 'host'",
-						"path is required when protocol is http or https",
-					},
+					Type:     model.ErrorType_ERROR_TYPE_ENTITY,
+					Messages: []string{"missing properties: 'host'"},
 				},
 			},
 		},
@@ -521,7 +518,6 @@ func TestService_Validate(t *testing.T) {
 					Type: model.ErrorType_ERROR_TYPE_ENTITY,
 					Messages: []string{
 						"missing properties: 'host'",
-						"path is required when protocol is http or https",
 					},
 				},
 			},
@@ -551,6 +547,16 @@ func TestService_Validate(t *testing.T) {
 			Service: func() Service {
 				s := NewService()
 				s.Service.Url = "https://foo"
+				_ = s.ProcessDefaults()
+				return s
+			},
+			wantErr: false,
+		},
+		{
+			name: "service with no path validates",
+			Service: func() Service {
+				s := goodService()
+				s.Service.Path = ""
 				_ = s.ProcessDefaults()
 				return s
 			},

--- a/internal/server/admin/service_test.go
+++ b/internal/server/admin/service_test.go
@@ -115,7 +115,6 @@ func TestServiceCreate(t *testing.T) {
 			String())
 		gotErr.Object().ValueEqual("messages", []string{
 			"missing properties: 'host'",
-			"path is required when protocol is http or https",
 		})
 	})
 	t.Run("creates a service with invalid protocol fails", func(t *testing.T) {
@@ -154,7 +153,7 @@ func TestServiceCreate(t *testing.T) {
 		body.Value("protocol").Equal("https")
 		body.Value("host").Equal("foo")
 		body.Value("port").Equal(443)
-		body.Value("path").Equal("/")
+		body.NotContainsKey("path")
 	})
 	t.Run("creating invalid service fails with 400", func(t *testing.T) {
 		svc := &v1.Service{


### PR DESCRIPTION
Right now koko enforces the presence of `path` when creating
services, while it defaults to `/` if `url` is used but the path
is missing from it.

This does not match the behaviour of Kong, which allows
an empty `path` on both cases:

```
$ http :8001/services name=test-no-path host=asd.org
{
    "ca_certificates": null,
    "client_certificate": null,
    "connect_timeout": 60000,
    "created_at": 1649256320,
    "enabled": true,
    "host": "asd.org",
    "id": "f0be23f9-3dce-4cd0-b41d-5f38258aab34",
    "name": "test-no-path",
    "path": null,
    "port": 80,
    "protocol": "http",
    "read_timeout": 60000,
    "retries": 5,
    "tags": null,
    "tls_verify": null,
    "tls_verify_depth": null,
    "updated_at": 1649256320,
    "write_timeout": 60000
}

$ http :8001/services name=test-url-no-path url=http://asd.org
{
    "ca_certificates": null,
    "client_certificate": null,
    "connect_timeout": 60000,
    "created_at": 1649256266,
    "enabled": true,
    "host": "asd.org",
    "id": "badf765c-7c83-47ae-b227-9c172c162126",
    "name": "test-url-no-path",
    "path": null,
    "port": 80,
    "protocol": "http",
    "read_timeout": 60000,
    "retries": 5,
    "tags": null,
    "tls_verify": null,
    "tls_verify_depth": null,
    "updated_at": 1649256266,
    "write_timeout": 60000
}
```

This PR makes sure koko behaves like Kong on this matter:

```
$ http :3000/v1/services\?cluster.id=4168295f-015e-4190-837e-0fcc5d72a52f name=test-no-path host=asd.org

{
    "item": {
        "connect_timeout": 60000,
        "created_at": 1649256223,
        "enabled": true,
        "host": "asd.org",
        "id": "3d0b2bdb-4a99-4d3d-beb5-835b5b8bebaa",
        "name": "test-no-path",
        "port": 80,
        "protocol": "http",
        "read_timeout": 60000,
        "retries": 5,
        "updated_at": 1649256223,
        "write_timeout": 60000
    }
}

$ http :3000/v1/services\?cluster.id=4168295f-015e-4190-837e-0fcc5d72a52f name=test-url-no-path url=http://asd.org
{
    "item": {
        "connect_timeout": 60000,
        "created_at": 1649256243,
        "enabled": true,
        "host": "asd.org",
        "id": "64ee9bae-5e96-4c63-a51e-4d5914c826d9",
        "name": "test-url-no-path",
        "port": 80,
        "protocol": "http",
        "read_timeout": 60000,
        "retries": 5,
        "updated_at": 1649256243,
        "write_timeout": 60000
    }
}
```