### PR TITLE
fix: routes' destinations and sources validation

### DIFF
--- a/internal/gen/jsonschema/schemas/route.json
+++ b/internal/gen/jsonschema/schemas/route.json
@@ -31,18 +31,18 @@
           }
         },
         "type": "object",
-        "oneOf": [
+        "anyOf": [
           {
             "required": [
               "ip"
             ],
-            "description": "either one of 'ip' or 'port' is required"
+            "description": "at least one of 'ip' or 'port' is required"
           },
           {
             "required": [
               "port"
             ],
-            "description": "either one of 'ip' or 'port' is required"
+            "description": "at least one of 'ip' or 'port' is required"
           }
         ]
       },
@@ -261,18 +261,18 @@
           }
         },
         "type": "object",
-        "oneOf": [
+        "anyOf": [
           {
             "required": [
               "ip"
             ],
-            "description": "either one of 'ip' or 'port' is required"
+            "description": "at least one of 'ip' or 'port' is required"
           },
           {
             "required": [
               "port"
             ],
-            "description": "either one of 'ip' or 'port' is required"
+            "description": "at least one of 'ip' or 'port' is required"
           }
         ]
       },

--- a/internal/model/json/validation/typedefs/fields.go
+++ b/internal/model/json/validation/typedefs/fields.go
@@ -153,13 +153,13 @@ var CIDRPort = &generator.Schema{
 		},
 		"port": Port,
 	},
-	OneOf: []*generator.Schema{
+	AnyOf: []*generator.Schema{
 		{
-			Description: "either one of 'ip' or 'port' is required",
+			Description: "at least one of 'ip' or 'port' is required",
 			Required:    []string{"ip"},
 		},
 		{
-			Description: "either one of 'ip' or 'port' is required",
+			Description: "at least one of 'ip' or 'port' is required",
 			Required:    []string{"port"},
 		},
 	},

--- a/internal/resource/route_test.go
+++ b/internal/resource/route_test.go
@@ -1111,6 +1111,40 @@ func TestRoute_Validate(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "validate destinations and sources",
+			Route: func() Route {
+				r := NewRoute()
+				_ = r.ProcessDefaults()
+				r.Route.Protocols = []string{typedefs.ProtocolTCP}
+				r.Route.Destinations = []*model.CIDRPort{
+					{
+						Ip: "192.0.2.0/24",
+					},
+					{
+						Port: 80,
+					},
+					{
+						Ip:   "192.0.2.0/24",
+						Port: 80,
+					},
+				}
+				r.Route.Sources = []*model.CIDRPort{
+					{
+						Ip: "203.0.113.0/24",
+					},
+					{
+						Port: 80,
+					},
+					{
+						Ip:   "203.0.113.0/24",
+						Port: 80,
+					},
+				}
+				return r
+			},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/server/admin/route_test.go
+++ b/internal/server/admin/route_test.go
@@ -94,6 +94,35 @@ func TestRouteCreate(t *testing.T) {
 		body := res.JSON().Path("$.item").Object()
 		body.Value("id").Equal(route.Id)
 	})
+	t.Run("creates a route with destinations and sources succeeds", func(t *testing.T) {
+		route := &v1.Route{
+			Name:      "quz",
+			Protocols: []string{"tcp"},
+			Destinations: []*v1.CIDRPort{
+				{
+					Ip:   "192.0.2.0/24",
+					Port: int32(80),
+				},
+				{
+					Ip: "198.51.100.0/24",
+				},
+				{
+					Port: 8080,
+				},
+			},
+			Sources: []*v1.CIDRPort{
+				{
+					Ip:   "203.0.113.0/24",
+					Port: int32(80),
+				},
+			},
+		}
+		res := c.POST("/v1/routes").WithJSON(route).Expect()
+		res.Status(http.StatusCreated)
+		body := res.JSON().Path("$.item").Object()
+		body.Value("destinations").Array().Length().Equal(3)
+		body.Value("sources").Array().Length().Equal(1)
+	})
 }
 
 func TestRouteUpsert(t *testing.T) {


### PR DESCRIPTION
Right now the CIDRPort model only supports only one
of  `ip` or  `port`, while Kong supports any combination
of both.

This fixes the model to match Kong and adds some tests.