### PR TITLE
test: handle version issues with nightly Kong Gateway OSS images

### DIFF
--- a/internal/test/e2e/basic_test.go
+++ b/internal/test/e2e/basic_test.go
@@ -697,12 +697,15 @@ func TestExpectedConfigHash(t *testing.T) {
 	res = c.POST("/v1/routes").WithJSON(fooRoute).Expect()
 	res.Status(201)
 
-	dpCleanup := run.KongDP(kong.GetKongConfForShared())
+	dockerInput := kong.GetKongConfForShared()
+	dpCleanup := run.KongDP(dockerInput)
 	defer dpCleanup()
 
 	// ensure kong node is up
 	require.Nil(t, util.WaitForKongPort(t, 8001))
-	kongClient.RunWhenKong(t, ">= 2.5.0")
+	if !util.IsNightlyKongImage(dockerInput) {
+		kongClient.RunWhenKong(t, ">= 2.5.0")
+	}
 
 	expectedConfig := &v1.TestingConfig{
 		Services: []*v1.Service{fooService},

--- a/internal/test/util/util.go
+++ b/internal/test/util/util.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
+	"github.com/kong/koko/internal/test/kong"
 )
 
 var (
@@ -113,4 +114,8 @@ func WaitForAdminAPI(t *testing.T) error {
 		fmt.Sprintf("admin-%d", defaultAdminPort),
 		http.StatusOK,
 	)
+}
+
+func IsNightlyKongImage(input kong.DockerInput) bool {
+	return strings.Contains(input.Image, "kong/kong:latest")
 }


### PR DESCRIPTION
This PR adds a special case for version parsing issues when using kong/kong:latest (nightly) image. These Docker images do not return the proper version of kong as the `kong/meta.lua` file has been modified to return only the SHA to which commit the Docker image belongs too. In order to handle testing properly a check for a SHA version number will occur for data plane nodes connecting and will return a version number greater that is outside the bounds of a released version.