### PR TITLE
tests: fix flaky test by using proper util function

### DIFF
--- a/internal/test/e2e/basic_test.go
+++ b/internal/test/e2e/basic_test.go
@@ -701,7 +701,7 @@ func TestExpectedConfigHash(t *testing.T) {
 	defer dpCleanup()
 
 	// ensure kong node is up
-	require.Nil(t, util.WaitForKongPort(t, 8001))
+	require.Nil(t, util.WaitForKongAdminAPI(t))
 	kongClient.RunWhenKong(t, ">= 2.5.0")
 
 	expectedConfig := &v1.TestingConfig{


### PR DESCRIPTION
For the `TestExpectedConfigHash` test, we are making sure to
run it only when Kong version is >= 2.5.0 by pulling the DP
version from the its Admin API. In order to do so, we need
to wait for the Admin API to be ready to accept requests.

This PR switches the existing util function in use with
another one (`WaitForKongAdminAPI`) doing exactly that.