### PR TITLE
fix: No-oping when node is not found when calling ClearStatus

### DIFF
--- a/internal/server/relay/status_service.go
+++ b/internal/server/relay/status_service.go
@@ -108,7 +108,7 @@ func (s StatusService) ClearStatus(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
-	if id == "" {
+	if statusID == "" {
 		return &relay.ClearStatusResponse{}, nil
 	}
 	err = db.Delete(ctx,

--- a/internal/server/relay/status_service_test.go
+++ b/internal/server/relay/status_service_test.go
@@ -260,6 +260,18 @@ func TestRelayStatusServiceClear(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, list.GetAll(), 0)
 	})
+	t.Run("clear status no-ops when node is not found", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
+
+		_, err = client.ClearStatus(ctx, &relay.ClearStatusRequest{
+			ContextReference: &model.EntityReference{
+				Type: "node",
+				Id:   uuid.NewString(),
+			},
+		})
+		require.NoError(t, err)
+	})
 	t.Run("clear status throws an error with invalid type", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(ctx)
 		defer cancel()


### PR DESCRIPTION
On the [StatusService.ClearStatus gRPC call](https://github.com/Kong/koko/blob/b532ffb9ca24199ceb3531263147d22eb78e1e7e/internal/server/relay/status_service.go#L90), in the event the status ID is unable to be fetched from the node ID, the `s.getCurrentStatusID()` method will return an empty ID with an empty error.

When this occurs, the Status object will be attempted to be deleted, and the following logs will be emitted:
```
{"level":"debug","ts":"2022-04-27T10:18:12.866-0500","caller":"relay/status_service.go:101","msg":"clear status invoked","component":"relay-server","type":"node","id":"2c325291-becf-4c0c-a285-d5f63a4e616c"}
{"level":"error","ts":"2022-04-27T10:20:09.488-0500","caller":"ws/manager.go:114","msg":"failed to clear status","component":"control-server","error":"rpc error: code = Unknown desc = no ID specified","node-id":"2c325291-becf-4c0c-a285-d5f63a4e616c","stacktrace":"..."}
```

This fixes an error in some conditional logic, along with introducing a test that replicates the issue & corrects it.