### PR TITLE
tests: updating HTTP status codes to use constant values

### DIFF
--- a/internal/resource/route_test.go
+++ b/internal/resource/route_test.go
@@ -46,7 +46,7 @@ func TestRoute_ProcessDefaults(t *testing.T) {
 	})
 	t.Run("defaults do not override explicit values", func(t *testing.T) {
 		r := NewRoute()
-		r.Route.HttpsRedirectStatusCode = 302
+		r.Route.HttpsRedirectStatusCode = http.StatusFound
 		r.Route.Protocols = []string{"grpc"}
 		r.Route.PathHandling = "v1"
 		r.Route.RegexPriority = wrapperspb.Int32(1)
@@ -67,7 +67,7 @@ func TestRoute_ProcessDefaults(t *testing.T) {
 			RequestBuffering:        wrapperspb.Bool(false),
 			ResponseBuffering:       wrapperspb.Bool(false),
 			PathHandling:            "v1",
-			HttpsRedirectStatusCode: 302,
+			HttpsRedirectStatusCode: http.StatusFound,
 		}, r.Resource())
 	})
 }

--- a/internal/server/admin/ca_certificate_test.go
+++ b/internal/server/admin/ca_certificate_test.go
@@ -327,7 +327,7 @@ func TestCACertificateUpsert(t *testing.T) {
 			Cert: goodCACertThree,
 		}
 		res := c.POST("/v1/ca-certificates").WithJSON(cert).Expect()
-		res.Status(201)
+		res.Status(http.StatusCreated)
 		body := res.JSON().Path("$.item").Object()
 		id := body.Value("id").String().Raw()
 
@@ -353,7 +353,7 @@ func TestCACertificateUpsert(t *testing.T) {
 		res := c.PUT("/v1/ca-certificates/{id}", uuid.NewString()).WithJSON(&v1.CACertificate{
 			Cert: "a",
 		}).Expect()
-		res.Status(400)
+		res.Status(http.StatusBadRequest)
 		body := res.JSON().Object()
 		body.ValueEqual("message", "validation error")
 		body.Value("details").Array().Length().Equal(1)

--- a/internal/server/admin/certificate_test.go
+++ b/internal/server/admin/certificate_test.go
@@ -284,7 +284,7 @@ func TestCertificateUpsert(t *testing.T) {
 			Key:  goodKeyTwo,
 		}
 		res := c.POST("/v1/certificates").WithJSON(certificate).Expect()
-		res.Status(201)
+		res.Status(http.StatusCreated)
 		body := res.JSON().Path("$.item").Object()
 		id := body.Value("id").String().Raw()
 
@@ -317,7 +317,7 @@ func TestCertificateUpsert(t *testing.T) {
 			Cert: "a",
 			Key:  "b",
 		}).Expect()
-		res.Status(400)
+		res.Status(http.StatusBadRequest)
 		body := res.JSON().Object()
 		body.ValueEqual("message", "validation error")
 		body.Value("details").Array().Length().Equal(2)

--- a/internal/server/admin/consumer_test.go
+++ b/internal/server/admin/consumer_test.go
@@ -36,7 +36,7 @@ func TestConsumerCreate(t *testing.T) {
 	t.Run("creating a empty consumer fails with 400", func(t *testing.T) {
 		consumer := &v1.Consumer{}
 		res := c.POST("/v1/consumers").WithJSON(consumer).Expect()
-		res.Status(400)
+		res.Status(http.StatusBadRequest)
 		body := res.JSON().Object()
 		body.ValueEqual("message", "validation error")
 		body.Value("details").Array().Length().Equal(1)
@@ -54,7 +54,7 @@ func TestConsumerCreate(t *testing.T) {
 			res := c.POST("/v1/consumers").
 				WithJSON(consumer).
 				Expect()
-			res.Status(201)
+			res.Status(http.StatusCreated)
 			res.Header("grpc-metadata-koko-status-code").Empty()
 			// Now try to create a new consumer with same username
 			res = c.POST("/v1/consumers").
@@ -78,7 +78,7 @@ func TestConsumerCreate(t *testing.T) {
 			res := c.POST("/v1/consumers").
 				WithJSON(consumer).
 				Expect()
-			res.Status(201)
+			res.Status(http.StatusCreated)
 			res.Header("grpc-metadata-koko-status-code").Empty()
 			// Now try to create a new consumer with same CustomID
 			res = c.POST("/v1/consumers").
@@ -99,7 +99,7 @@ func TestConsumerCreate(t *testing.T) {
 		consumer.CustomId = "withCustomID"
 		consumer.Id = uuid.NewString()
 		res := c.POST("/v1/consumers").WithJSON(consumer).Expect()
-		res.Status(201)
+		res.Status(http.StatusCreated)
 		body := res.JSON().Path("$.item").Object()
 		body.Value("id").Equal(consumer.Id)
 	})
@@ -108,7 +108,7 @@ func TestConsumerCreate(t *testing.T) {
 		consumer.Username = "withSpaces"
 		consumer.CustomId = "custom ID"
 		res := c.POST("/v1/consumers").WithJSON(consumer).Expect()
-		res.Status(201)
+		res.Status(http.StatusCreated)
 		body := res.JSON().Path("$.item").Object()
 		body.Value("username").String().Equal("withSpaces")
 		body.Value("custom_id").String().Equal("custom ID")

--- a/internal/server/admin/plugin_test.go
+++ b/internal/server/admin/plugin_test.go
@@ -65,7 +65,7 @@ func TestPluginCreate(t *testing.T) {
 		pluginBytes, err := json.Marshal(goodKeyAuthPlugin())
 		require.Nil(t, err)
 		res := c.POST("/v1/plugins").WithBytes(pluginBytes).Expect()
-		res.Status(201)
+		res.Status(http.StatusCreated)
 		res.Header("grpc-metadata-koko-status-code").Empty()
 		body := res.JSON().Path("$.item").Object()
 		validateKeyAuthPlugin(body)
@@ -74,7 +74,7 @@ func TestPluginCreate(t *testing.T) {
 		pluginBytes, err := json.Marshal(goodKeyAuthPlugin())
 		require.Nil(t, err)
 		res := c.POST("/v1/plugins").WithBytes(pluginBytes).Expect()
-		res.Status(400)
+		res.Status(http.StatusBadRequest)
 		body := res.JSON().Object()
 		body.ValueEqual("message", "data constraint error")
 		body.Value("details").Array().Length().Equal(1)
@@ -97,7 +97,7 @@ func TestPluginCreate(t *testing.T) {
 		pluginBytes, err := json.Marshal(plugin)
 		require.Nil(t, err)
 		res := c.POST("/v1/plugins").WithBytes(pluginBytes).Expect()
-		res.Status(400)
+		res.Status(http.StatusBadRequest)
 		body := res.JSON().Object()
 		body.ValueEqual("message", "data constraint error")
 		body.Value("details").Array().Length().Equal(1)
@@ -110,7 +110,7 @@ func TestPluginCreate(t *testing.T) {
 		service := goodService()
 		service.Id = uuid.NewString()
 		res := c.POST("/v1/services").WithJSON(service).Expect()
-		res.Status(201)
+		res.Status(http.StatusCreated)
 		plugin := &v1.Plugin{
 			Name: "key-auth",
 			Service: &v1.Service{
@@ -120,7 +120,7 @@ func TestPluginCreate(t *testing.T) {
 		pluginBytes, err := json.Marshal(plugin)
 		require.Nil(t, err)
 		res = c.POST("/v1/plugins").WithBytes(pluginBytes).Expect()
-		res.Status(201)
+		res.Status(http.StatusCreated)
 	})
 	t.Run("creating a plugin with a non-existent route fails", func(t *testing.T) {
 		plugin := &v1.Plugin{
@@ -134,7 +134,7 @@ func TestPluginCreate(t *testing.T) {
 		pluginBytes, err := json.Marshal(plugin)
 		require.Nil(t, err)
 		res := c.POST("/v1/plugins").WithBytes(pluginBytes).Expect()
-		res.Status(400)
+		res.Status(http.StatusBadRequest)
 		body := res.JSON().Object()
 		body.ValueEqual("message", "data constraint error")
 		body.Value("details").Array().Length().Equal(1)
@@ -147,7 +147,7 @@ func TestPluginCreate(t *testing.T) {
 		route := goodRoute()
 		route.Id = uuid.NewString()
 		res := c.POST("/v1/routes").WithJSON(route).Expect()
-		res.Status(201)
+		res.Status(http.StatusCreated)
 		plugin := &v1.Plugin{
 			Name: "key-auth",
 			Route: &v1.Route{
@@ -157,7 +157,7 @@ func TestPluginCreate(t *testing.T) {
 		pluginBytes, err := json.Marshal(plugin)
 		require.Nil(t, err)
 		res = c.POST("/v1/plugins").WithBytes(pluginBytes).Expect()
-		res.Status(201)
+		res.Status(http.StatusCreated)
 	})
 
 	t.Run("creating a plugin with a valid consumer.id succeeds", func(t *testing.T) {
@@ -191,13 +191,13 @@ func TestPluginCreate(t *testing.T) {
 			service.Id = uuid.NewString()
 			service.Name = "foo-plugin-service"
 			res := c.POST("/v1/services").WithJSON(service).Expect()
-			res.Status(201)
+			res.Status(http.StatusCreated)
 
 			route := goodRoute()
 			route.Id = uuid.NewString()
 			route.Name = "foo-plugin-route"
 			res = c.POST("/v1/routes").WithJSON(route).Expect()
-			res.Status(201)
+			res.Status(http.StatusCreated)
 
 			plugin := &v1.Plugin{
 				Name: "key-auth",
@@ -211,7 +211,7 @@ func TestPluginCreate(t *testing.T) {
 			pluginBytes, err := json.Marshal(plugin)
 			require.Nil(t, err)
 			res = c.POST("/v1/plugins").WithBytes(pluginBytes).Expect()
-			res.Status(201)
+			res.Status(http.StatusCreated)
 		})
 	t.Run("creating a unknown plugin error",
 		func(t *testing.T) {
@@ -221,7 +221,7 @@ func TestPluginCreate(t *testing.T) {
 			pluginBytes, err := json.Marshal(plugin)
 			require.Nil(t, err)
 			res := c.POST("/v1/plugins").WithBytes(pluginBytes).Expect()
-			res.Status(400)
+			res.Status(http.StatusBadRequest)
 			body := res.JSON().Object()
 			body.ValueEqual("message", "validation error")
 			body.Value("details").Array().Length().Equal(1)
@@ -239,7 +239,7 @@ func TestPluginCreate(t *testing.T) {
 			Id:   uuid.NewString(),
 		}
 		res := c.POST("/v1/plugins").WithJSON(plugin).Expect()
-		res.Status(201)
+		res.Status(http.StatusCreated)
 		body := res.JSON().Path("$.item").Object()
 		body.Value("id").Equal(plugin.Id)
 	})
@@ -290,7 +290,7 @@ func TestPluginUpsert(t *testing.T) {
 		res := c.PUT("/v1/plugins/" + uuid.NewString()).
 			WithBytes(pluginBytes).
 			Expect()
-		res.Status(400)
+		res.Status(http.StatusBadRequest)
 		body := res.JSON().Object()
 		body.ValueEqual("message", "data constraint error")
 		body.Value("details").Array().Length().Equal(1)
@@ -351,13 +351,13 @@ func TestPluginDelete(t *testing.T) {
 	require.Nil(t, err)
 	res := c.POST("/v1/plugins").WithBytes(pluginBytes).Expect()
 	id := res.JSON().Path("$.item.id").String().Raw()
-	res.Status(201)
+	res.Status(http.StatusCreated)
 	t.Run("deleting a non-existent plugin returns 404", func(t *testing.T) {
 		randomID := "071f5040-3e4a-46df-9d98-451e79e318fd"
-		c.DELETE("/v1/plugins/" + randomID).Expect().Status(404)
+		c.DELETE("/v1/plugins/" + randomID).Expect().Status(http.StatusNotFound)
 	})
 	t.Run("deleting a plugin return 204", func(t *testing.T) {
-		c.DELETE("/v1/plugins/" + id).Expect().Status(204)
+		c.DELETE("/v1/plugins/" + id).Expect().Status(http.StatusNoContent)
 	})
 	t.Run("delete request without an ID returns 400", func(t *testing.T) {
 		res := c.DELETE("/v1/plugins/").Expect()
@@ -380,11 +380,11 @@ func TestPluginRead(t *testing.T) {
 	pluginBytes, err := json.Marshal(goodKeyAuthPlugin())
 	require.Nil(t, err)
 	res := c.POST("/v1/plugins").WithBytes(pluginBytes).Expect()
-	res.Status(201)
+	res.Status(http.StatusCreated)
 	id := res.JSON().Path("$.item.id").String().Raw()
 	t.Run("reading a non-existent plugin returns 404", func(t *testing.T) {
 		randomID := "071f5040-3e4a-46df-9d98-451e79e318fd"
-		c.GET("/v1/plugins/" + randomID).Expect().Status(404)
+		c.GET("/v1/plugins/" + randomID).Expect().Status(http.StatusNotFound)
 	})
 	t.Run("reading a plugin return 200", func(t *testing.T) {
 		res := c.GET("/v1/plugins/" + id).Expect().Status(http.StatusOK)
@@ -492,7 +492,7 @@ func TestPluginList(t *testing.T) {
 		Path: "/foo",
 	}
 	res := c.POST("/v1/services").WithJSON(svc).Expect()
-	res.Status(201)
+	res.Status(http.StatusCreated)
 	serviceID1 := res.JSON().Path("$.item.id").String().Raw()
 	svc = &v1.Service{
 		Name: "bar",
@@ -500,7 +500,7 @@ func TestPluginList(t *testing.T) {
 		Path: "/bar",
 	}
 	res = c.POST("/v1/services").WithJSON(svc).Expect()
-	res.Status(201)
+	res.Status(http.StatusCreated)
 	serviceID2 := res.JSON().Path("$.item.id").String().Raw()
 	svc = &v1.Service{
 		Name: "baz",
@@ -508,7 +508,7 @@ func TestPluginList(t *testing.T) {
 		Path: "/baz",
 	}
 	res = c.POST("/v1/services").WithJSON(svc).Expect()
-	res.Status(201)
+	res.Status(http.StatusCreated)
 	serviceID3 := res.JSON().Path("$.item.id").String().Raw()
 
 	rte := &v1.Route{
@@ -516,27 +516,27 @@ func TestPluginList(t *testing.T) {
 		Paths: []string{"/qux"},
 	}
 	res = c.POST("/v1/routes").WithJSON(rte).Expect()
-	res.Status(201)
+	res.Status(http.StatusCreated)
 	routeID1 := res.JSON().Path("$.item.id").String().Raw()
 	rte = &v1.Route{
 		Name:  "quux",
 		Paths: []string{"/quux"},
 	}
 	res = c.POST("/v1/routes").WithJSON(rte).Expect()
-	res.Status(201)
+	res.Status(http.StatusCreated)
 	routeID2 := res.JSON().Path("$.item.id").String().Raw()
 	rte = &v1.Route{
 		Name:  "quuz",
 		Paths: []string{"/quuz"},
 	}
 	res = c.POST("/v1/routes").WithJSON(rte).Expect()
-	res.Status(201)
+	res.Status(http.StatusCreated)
 	routeID3 := res.JSON().Path("$.item.id").String().Raw()
 
 	pluginBytes, err := json.Marshal(goodKeyAuthPlugin())
 	require.Nil(t, err)
 	res = c.POST("/v1/plugins").WithBytes(pluginBytes).Expect()
-	res.Status(201)
+	res.Status(http.StatusCreated)
 	pluginID1 := res.JSON().Path("$.item.id").String().Raw()
 	plg := &v1.Plugin{
 		Name:      "request-transformer",
@@ -546,7 +546,7 @@ func TestPluginList(t *testing.T) {
 	pluginBytes, err = json.Marshal(plg)
 	require.Nil(t, err)
 	res = c.POST("/v1/plugins").WithBytes(pluginBytes).Expect()
-	res.Status(201)
+	res.Status(http.StatusCreated)
 	pluginID2 := res.JSON().Path("$.item.id").String().Raw()
 	plg = &v1.Plugin{
 		Name:      "basic-auth",
@@ -559,7 +559,7 @@ func TestPluginList(t *testing.T) {
 	pluginBytes, err = json.Marshal(plg)
 	require.Nil(t, err)
 	res = c.POST("/v1/plugins").WithBytes(pluginBytes).Expect()
-	res.Status(201)
+	res.Status(http.StatusCreated)
 	pluginID3 := res.JSON().Path("$.item.id").String().Raw()
 	plg = &v1.Plugin{
 		Name:      "bot-detection",
@@ -572,7 +572,7 @@ func TestPluginList(t *testing.T) {
 	pluginBytes, err = json.Marshal(plg)
 	require.Nil(t, err)
 	res = c.POST("/v1/plugins").WithBytes(pluginBytes).Expect()
-	res.Status(201)
+	res.Status(http.StatusCreated)
 	pluginID4 := res.JSON().Path("$.item.id").String().Raw()
 	plg = &v1.Plugin{
 		Name:      "cors",
@@ -585,7 +585,7 @@ func TestPluginList(t *testing.T) {
 	pluginBytes, err = json.Marshal(plg)
 	require.Nil(t, err)
 	res = c.POST("/v1/plugins").WithBytes(pluginBytes).Expect()
-	res.Status(201)
+	res.Status(http.StatusCreated)
 	pluginID5 := res.JSON().Path("$.item.id").String().Raw()
 	plg = &v1.Plugin{
 		Name:      "hmac-auth",
@@ -598,7 +598,7 @@ func TestPluginList(t *testing.T) {
 	pluginBytes, err = json.Marshal(plg)
 	require.Nil(t, err)
 	res = c.POST("/v1/plugins").WithBytes(pluginBytes).Expect()
-	res.Status(201)
+	res.Status(http.StatusCreated)
 	pluginID6 := res.JSON().Path("$.item.id").String().Raw()
 	plg = &v1.Plugin{
 		Name:      "jwt",
@@ -611,7 +611,7 @@ func TestPluginList(t *testing.T) {
 	pluginBytes, err = json.Marshal(plg)
 	require.Nil(t, err)
 	res = c.POST("/v1/plugins").WithBytes(pluginBytes).Expect()
-	res.Status(201)
+	res.Status(http.StatusCreated)
 	pluginID7 := res.JSON().Path("$.item.id").String().Raw()
 	plg = &v1.Plugin{
 		Name:      "request-size-limiting",
@@ -624,7 +624,7 @@ func TestPluginList(t *testing.T) {
 	pluginBytes, err = json.Marshal(plg)
 	require.Nil(t, err)
 	res = c.POST("/v1/plugins").WithBytes(pluginBytes).Expect()
-	res.Status(201)
+	res.Status(http.StatusCreated)
 	pluginID8 := res.JSON().Path("$.item.id").String().Raw()
 
 	t.Run("list all plugins", func(t *testing.T) {
@@ -846,7 +846,7 @@ func TestPluginListByConsumer(t *testing.T) {
 	pluginBytes, err = json.Marshal(plugin)
 	require.Nil(t, err)
 	res = c.POST("/v1/plugins").WithBytes(pluginBytes).Expect()
-	res.Status(201)
+	res.Status(http.StatusCreated)
 
 	body = c.GET("/v1/plugins").WithQuery("consumer_id", consumerID).
 		Expect().Status(http.StatusOK).JSON().Object()

--- a/internal/server/admin/schemas_test.go
+++ b/internal/server/admin/schemas_test.go
@@ -2,6 +2,7 @@ package admin
 
 import (
 	"fmt"
+	"net/http"
 	"testing"
 
 	"github.com/gavv/httpexpect/v2"
@@ -23,7 +24,7 @@ func TestSchemasGetEntity(t *testing.T) {
 
 		for _, path := range paths {
 			res := c.GET(fmt.Sprintf("/v1/schemas/json/%s", path)).Expect()
-			res.Status(200)
+			res.Status(http.StatusOK)
 			value := res.JSON().Path("$.type").String()
 			value.Equal("object") // all JSON schemas indicate type object
 		}
@@ -39,7 +40,7 @@ func TestSchemasGetEntity(t *testing.T) {
 
 		for _, path := range paths {
 			res := c.GET(fmt.Sprintf("/v1/schemas/json/%s", path)).Expect()
-			res.Status(404)
+			res.Status(http.StatusNotFound)
 			message := res.JSON().Path("$.message").String()
 			message.Equal(fmt.Sprintf("no entity named '%s'", path))
 		}
@@ -47,7 +48,7 @@ func TestSchemasGetEntity(t *testing.T) {
 
 	t.Run("ensure the path/name is present", func(t *testing.T) {
 		res := c.GET("/v1/schemas/json/").Expect()
-		res.Status(400)
+		res.Status(http.StatusBadRequest)
 		message := res.JSON().Path("$.message").String()
 		message.Equal("required name is missing")
 	})
@@ -69,7 +70,7 @@ func TestSchemasGetPlugin(t *testing.T) {
 
 		for _, path := range paths {
 			res := c.GET(fmt.Sprintf("/v1/schemas/lua/plugins/%s", path)).Expect()
-			res.Status(200)
+			res.Status(http.StatusOK)
 			value := res.JSON().Path("$..protocols").Array()
 			value.NotEmpty()
 			value = res.JSON().Path("$..config.required").Array()
@@ -88,7 +89,7 @@ func TestSchemasGetPlugin(t *testing.T) {
 
 		for _, path := range paths {
 			res := c.GET(fmt.Sprintf("/v1/schemas/lua/plugins/%s", path)).Expect()
-			res.Status(404)
+			res.Status(http.StatusNotFound)
 			message := res.JSON().Path("$.message").String()
 			message.Equal(fmt.Sprintf("no plugin named '%s'", path))
 		}
@@ -96,7 +97,7 @@ func TestSchemasGetPlugin(t *testing.T) {
 
 	t.Run("ensure the path/name is present", func(t *testing.T) {
 		res := c.GET("/v1/schemas/lua/plugins/").Expect()
-		res.Status(400)
+		res.Status(http.StatusBadRequest)
 		message := res.JSON().Path("$.message").String()
 		message.Equal("required name is missing")
 	})

--- a/internal/server/admin/status_test.go
+++ b/internal/server/admin/status_test.go
@@ -46,7 +46,7 @@ func TestStatusRead(t *testing.T) {
 
 	t.Run("reading a non-existent status returns 404", func(t *testing.T) {
 		randomID := "071f5040-3e4a-46df-9d98-451e79e318fd"
-		c.GET("/v1/statuses/" + randomID).Expect().Status(404)
+		c.GET("/v1/statuses/" + randomID).Expect().Status(http.StatusNotFound)
 	})
 	t.Run("reading a status return 200", func(t *testing.T) {
 		res := c.GET("/v1/statuses/" + statusID).Expect().Status(http.StatusOK)
@@ -59,7 +59,7 @@ func TestStatusRead(t *testing.T) {
 		body.Path("$.conditions[0].severity").String().Equal("error")
 	})
 	t.Run("read request without an ID returns 400", func(t *testing.T) {
-		c.GET("/v1/statuses/").Expect().Status(400)
+		c.GET("/v1/statuses/").Expect().Status(http.StatusBadRequest)
 	})
 }
 
@@ -94,13 +94,13 @@ func TestStatusDelete(t *testing.T) {
 
 	t.Run("deleting a non-existent status returns 404", func(t *testing.T) {
 		randomID := "071f5040-3e4a-46df-9d98-451e79e318fd"
-		c.DELETE("/v1/statuses/" + randomID).Expect().Status(404)
+		c.DELETE("/v1/statuses/" + randomID).Expect().Status(http.StatusNotFound)
 	})
 	t.Run("deleting a status return 204", func(t *testing.T) {
-		c.DELETE("/v1/statuses/" + statusID).Expect().Status(204)
+		c.DELETE("/v1/statuses/" + statusID).Expect().Status(http.StatusNoContent)
 	})
 	t.Run("delete request without an ID returns 400", func(t *testing.T) {
-		c.DELETE("/v1/statuses/").Expect().Status(400)
+		c.DELETE("/v1/statuses/").Expect().Status(http.StatusBadRequest)
 	})
 }
 

--- a/internal/server/admin/target_test.go
+++ b/internal/server/admin/target_test.go
@@ -18,7 +18,7 @@ func TestTargetCreate(t *testing.T) {
 	upstream := goodUpstream()
 	upstream.Id = uuid.NewString()
 	res := c.POST("/v1/upstreams").WithJSON(upstream).Expect()
-	res.Status(201)
+	res.Status(http.StatusCreated)
 
 	t.Run("creating a target with a non-existent upstream fails",
 		func(t *testing.T) {
@@ -31,7 +31,7 @@ func TestTargetCreate(t *testing.T) {
 			}
 
 			res := c.PUT("/v1/targets/" + target.Id).WithJSON(target).Expect()
-			res.Status(400)
+			res.Status(http.StatusBadRequest)
 			body := res.JSON().Object()
 			body.ValueEqual("message", "data constraint error")
 			body.Value("details").Array().Length().Equal(1)
@@ -47,7 +47,7 @@ func TestTargetCreate(t *testing.T) {
 			},
 		}
 		res = c.POST("/v1/targets").WithJSON(target).Expect()
-		res.Status(201)
+		res.Status(http.StatusCreated)
 	})
 	t.Run("recreating the same target on the same upstream fails", func(t *testing.T) {
 		target := &v1.Target{
@@ -58,7 +58,7 @@ func TestTargetCreate(t *testing.T) {
 			},
 		}
 		res := c.PUT("/v1/targets/" + target.Id).WithJSON(target).Expect()
-		res.Status(400)
+		res.Status(http.StatusBadRequest)
 		body := res.JSON().Object()
 		body.ValueEqual("message", "data constraint error")
 		body.Value("details").Array().Length().Equal(1)
@@ -72,7 +72,7 @@ func TestTargetCreate(t *testing.T) {
 		upstream.Name = "bar"
 		upstream.Id = uuid.NewString()
 		res := c.PUT("/v1/upstreams/" + upstream.Id).WithJSON(upstream).Expect()
-		res.Status(200)
+		res.Status(http.StatusOK)
 
 		target := &v1.Target{
 			Target: "10.42.42.42",
@@ -81,7 +81,7 @@ func TestTargetCreate(t *testing.T) {
 			},
 		}
 		res = c.POST("/v1/targets").WithJSON(target).Expect()
-		res.Status(201)
+		res.Status(http.StatusCreated)
 	})
 	t.Run("creating a target with an invalid target fails", func(t *testing.T) {
 		target := &v1.Target{
@@ -91,7 +91,7 @@ func TestTargetCreate(t *testing.T) {
 			},
 		}
 		res = c.POST("/v1/targets").WithJSON(target).Expect()
-		res.Status(400)
+		res.Status(http.StatusBadRequest)
 		body := res.JSON().Object()
 		body.ValueEqual("message", "validation error")
 		body.Value("details").Array().Length().Equal(1)
@@ -107,7 +107,7 @@ func TestTargetCreate(t *testing.T) {
 			},
 		}
 		res = c.POST("/v1/targets").WithJSON(target).Expect()
-		res.Status(400)
+		res.Status(http.StatusBadRequest)
 		body := res.JSON().Object()
 		body.ValueEqual("message", "validation error")
 		body.Value("details").Array().Length().Equal(1)
@@ -123,7 +123,7 @@ func TestTargetCreate(t *testing.T) {
 			},
 		}
 		res = c.POST("/v1/targets").WithJSON(target).Expect()
-		res.Status(400)
+		res.Status(http.StatusBadRequest)
 		body := res.JSON().Object()
 		body.ValueEqual("message", "validation error")
 		body.Value("details").Array().Length().Equal(1)
@@ -139,7 +139,7 @@ func TestTargetCreate(t *testing.T) {
 			},
 		}
 		res = c.POST("/v1/targets").WithJSON(target).Expect()
-		res.Status(400)
+		res.Status(http.StatusBadRequest)
 		body := res.JSON().Object()
 		body.ValueEqual("message", "validation error")
 		body.Value("details").Array().Length().Equal(1)
@@ -156,7 +156,7 @@ func TestTargetCreate(t *testing.T) {
 			Id: uuid.NewString(),
 		}
 		res := c.POST("/v1/targets").WithJSON(target).Expect()
-		res.Status(201)
+		res.Status(http.StatusCreated)
 		body := res.JSON().Path("$.item").Object()
 		body.Value("id").Equal(target.Id)
 	})
@@ -170,7 +170,7 @@ func TestTargetUpsert(t *testing.T) {
 	upstream := goodUpstream()
 	upstream.Id = uuid.NewString()
 	res := c.POST("/v1/upstreams").WithJSON(upstream).Expect()
-	res.Status(201)
+	res.Status(http.StatusCreated)
 
 	t.Run("creating a target with a non-existent upstream fails", func(t *testing.T) {
 		target := &v1.Target{
@@ -181,7 +181,7 @@ func TestTargetUpsert(t *testing.T) {
 		}
 		targetID := uuid.NewString()
 		res := c.PUT("/v1/targets/" + targetID).WithJSON(target).Expect()
-		res.Status(400)
+		res.Status(http.StatusBadRequest)
 		body := res.JSON().Object()
 		body.ValueEqual("message", "data constraint error")
 		body.Value("details").Array().Length().Equal(1)
@@ -198,7 +198,7 @@ func TestTargetUpsert(t *testing.T) {
 		}
 		targetID := uuid.NewString()
 		res = c.PUT("/v1/targets/" + targetID).WithJSON(target).Expect()
-		res.Status(200)
+		res.Status(http.StatusOK)
 		res.JSON().Object().Path("$.item.id").Equal(targetID)
 	})
 	t.Run("recreating the same target on the same upstream fails", func(t *testing.T) {
@@ -210,7 +210,7 @@ func TestTargetUpsert(t *testing.T) {
 		}
 		targetID := uuid.NewString()
 		res := c.PUT("/v1/targets/" + targetID).WithJSON(target).Expect()
-		res.Status(400)
+		res.Status(http.StatusBadRequest)
 		body := res.JSON().Object()
 		body.ValueEqual("message", "data constraint error")
 		body.Value("details").Array().Length().Equal(1)
@@ -228,14 +228,14 @@ func TestTargetUpsert(t *testing.T) {
 		}
 		targetID := uuid.NewString()
 		res = c.PUT("/v1/targets/" + targetID).WithJSON(target).Expect()
-		res.Status(200)
+		res.Status(http.StatusOK)
 		res.JSON().Object().Path("$.item.id").Equal(targetID)
 		res.JSON().Object().Path("$.item.upstream.id").Equal(upstream.Id)
 
 		newUpstream := goodUpstream()
 		newUpstream.Name = "baz"
 		res := c.POST("/v1/upstreams").WithJSON(newUpstream).Expect()
-		res.Status(201)
+		res.Status(http.StatusCreated)
 		newUpstreamID := res.JSON().Object().Path("$.item.id").String().Raw()
 		newTarget := &v1.Target{
 			Target: "10.60.24.7",
@@ -244,7 +244,7 @@ func TestTargetUpsert(t *testing.T) {
 			},
 		}
 		res = c.PUT("/v1/targets/" + targetID).WithJSON(newTarget).Expect()
-		res.Status(200)
+		res.Status(http.StatusOK)
 		object := res.JSON().Object().Path("$.item").Object()
 		object.Value("id").Equal(targetID)
 		object.Value("target").Equal("10.60.24.7:8000")
@@ -272,7 +272,7 @@ func TestTargetDelete(t *testing.T) {
 	c := httpexpect.New(t, s.URL)
 	upstream := goodUpstream()
 	res := c.POST("/v1/upstreams").WithJSON(upstream).Expect()
-	res.Status(201)
+	res.Status(http.StatusCreated)
 	upstreamID := res.JSON().Object().Path("$.item.id").String().Raw()
 
 	target := &v1.Target{
@@ -282,15 +282,15 @@ func TestTargetDelete(t *testing.T) {
 		},
 	}
 	res = c.POST("/v1/targets").WithJSON(target).Expect()
-	res.Status(201)
+	res.Status(http.StatusCreated)
 	targetID := res.JSON().Object().Path("$.item.id").String().Raw()
 
 	t.Run("deleting a non-existent target returns 404", func(t *testing.T) {
 		randomID := "071f5040-3e4a-46df-9d98-451e79e318fd"
-		c.DELETE("/v1/targets/" + randomID).Expect().Status(404)
+		c.DELETE("/v1/targets/" + randomID).Expect().Status(http.StatusNotFound)
 	})
 	t.Run("deleting a target return 204", func(t *testing.T) {
-		c.DELETE("/v1/targets/" + targetID).Expect().Status(204)
+		c.DELETE("/v1/targets/" + targetID).Expect().Status(http.StatusNoContent)
 	})
 	t.Run("delete request without an ID returns 400", func(t *testing.T) {
 		res := c.DELETE("/v1/targets/").Expect()
@@ -312,7 +312,7 @@ func TestTargetRead(t *testing.T) {
 	c := httpexpect.New(t, s.URL)
 	upstream := goodUpstream()
 	res := c.POST("/v1/upstreams").WithJSON(upstream).Expect()
-	res.Status(201)
+	res.Status(http.StatusCreated)
 	upstreamID := res.JSON().Object().Path("$.item.id").String().Raw()
 
 	target := &v1.Target{
@@ -322,12 +322,12 @@ func TestTargetRead(t *testing.T) {
 		},
 	}
 	res = c.POST("/v1/targets").WithJSON(target).Expect()
-	res.Status(201)
+	res.Status(http.StatusCreated)
 	targetID := res.JSON().Object().Path("$.item.id").String().Raw()
 
 	t.Run("reading a non-existent target returns 404", func(t *testing.T) {
 		randomID := "071f5040-3e4a-46df-9d98-451e79e318fd"
-		c.GET("/v1/targets/" + randomID).Expect().Status(404)
+		c.GET("/v1/targets/" + randomID).Expect().Status(http.StatusNotFound)
 	})
 	t.Run("reading a target return 200", func(t *testing.T) {
 		res := c.GET("/v1/targets/" + targetID).Expect().Status(http.StatusOK)
@@ -353,21 +353,21 @@ func TestTargetList(t *testing.T) {
 		Name: "foo",
 	}
 	res := c.POST("/v1/upstreams").WithJSON(upstream).Expect()
-	res.Status(201)
+	res.Status(http.StatusCreated)
 
 	upstreamID1 := res.JSON().Path("$.item.id").String().Raw()
 	upstream = &v1.Upstream{
 		Name: "bar",
 	}
 	res = c.POST("/v1/upstreams").WithJSON(upstream).Expect()
-	res.Status(201)
+	res.Status(http.StatusCreated)
 	upstreamID2 := res.JSON().Path("$.item.id").String().Raw()
 
 	upstream = &v1.Upstream{
 		Name: "baz",
 	}
 	res = c.POST("/v1/upstreams").WithJSON(upstream).Expect()
-	res.Status(201)
+	res.Status(http.StatusCreated)
 	upstreamID3 := res.JSON().Path("$.item.id").String().Raw()
 
 	target := &v1.Target{
@@ -377,7 +377,7 @@ func TestTargetList(t *testing.T) {
 		Target: "10.0.42.1",
 	}
 	res = c.POST("/v1/targets").WithJSON(target).Expect()
-	res.Status(201)
+	res.Status(http.StatusCreated)
 	targetID1 := res.JSON().Path("$.item.id").String().Raw()
 	target = &v1.Target{
 		Upstream: &v1.Upstream{
@@ -386,7 +386,7 @@ func TestTargetList(t *testing.T) {
 		Target: "10.0.42.2",
 	}
 	res = c.POST("/v1/targets").WithJSON(target).Expect()
-	res.Status(201)
+	res.Status(http.StatusCreated)
 	targetID2 := res.JSON().Path("$.item.id").String().Raw()
 
 	target = &v1.Target{
@@ -396,7 +396,7 @@ func TestTargetList(t *testing.T) {
 		Target: "10.0.42.3",
 	}
 	res = c.POST("/v1/targets").WithJSON(target).Expect()
-	res.Status(201)
+	res.Status(http.StatusCreated)
 	targetID3 := res.JSON().Path("$.item.id").String().Raw()
 
 	target = &v1.Target{
@@ -406,7 +406,7 @@ func TestTargetList(t *testing.T) {
 		Target: "10.0.42.4",
 	}
 	res = c.POST("/v1/targets").WithJSON(target).Expect()
-	res.Status(201)
+	res.Status(http.StatusCreated)
 	targetID4 := res.JSON().Path("$.item.id").String().Raw()
 
 	target = &v1.Target{
@@ -416,7 +416,7 @@ func TestTargetList(t *testing.T) {
 		Target: "10.0.42.5",
 	}
 	res = c.POST("/v1/targets").WithJSON(target).Expect()
-	res.Status(201)
+	res.Status(http.StatusCreated)
 	targetID5 := res.JSON().Path("$.item.id").String().Raw()
 
 	t.Run("list all targets", func(t *testing.T) {

--- a/internal/test/e2e/basic_test.go
+++ b/internal/test/e2e/basic_test.go
@@ -82,7 +82,7 @@ func TestSharedMTLS(t *testing.T) {
 	}
 	c := httpexpect.New(t, "http://localhost:3000")
 	res := c.POST("/v1/services").WithJSON(service).Expect()
-	res.Status(201)
+	res.Status(http.StatusCreated)
 	route := &v1.Route{
 		Name:  "bar",
 		Paths: []string{"/"},
@@ -91,7 +91,7 @@ func TestSharedMTLS(t *testing.T) {
 		},
 	}
 	res = c.POST("/v1/routes").WithJSON(route).Expect()
-	res.Status(201)
+	res.Status(http.StatusCreated)
 
 	dpCleanup := run.KongDP(kong.GetKongConfForShared())
 	defer dpCleanup()
@@ -121,7 +121,7 @@ func TestPKIMTLS(t *testing.T) {
 	}
 	c := httpexpect.New(t, "http://localhost:3000")
 	res := c.POST("/v1/services").WithJSON(service).Expect()
-	res.Status(201)
+	res.Status(http.StatusCreated)
 	route := &v1.Route{
 		Name:  "bar",
 		Paths: []string{"/"},
@@ -130,7 +130,7 @@ func TestPKIMTLS(t *testing.T) {
 		},
 	}
 	res = c.POST("/v1/routes").WithJSON(route).Expect()
-	res.Status(201)
+	res.Status(http.StatusCreated)
 
 	dpCleanup := run.KongDP(kong.GetKongConf())
 	defer dpCleanup()
@@ -188,7 +188,7 @@ func TestNodesEndpoint(t *testing.T) {
 	}
 	c := httpexpect.New(t, "http://localhost:3000")
 	res := c.POST("/v1/services").WithJSON(service).Expect()
-	res.Status(201)
+	res.Status(http.StatusCreated)
 	route := &v1.Route{
 		Name:  "bar",
 		Paths: []string{"/"},
@@ -197,7 +197,7 @@ func TestNodesEndpoint(t *testing.T) {
 		},
 	}
 	res = c.POST("/v1/routes").WithJSON(route).Expect()
-	res.Status(201)
+	res.Status(http.StatusCreated)
 
 	dpCleanup := run.KongDP(kong.GetKongConfForShared())
 	defer dpCleanup()
@@ -245,7 +245,7 @@ func TestPluginSync(t *testing.T) {
 	}
 	c := httpexpect.New(t, "http://localhost:3000")
 	res := c.POST("/v1/services").WithJSON(service).Expect()
-	res.Status(201)
+	res.Status(http.StatusCreated)
 
 	route := &v1.Route{
 		Id:    uuid.NewString(),
@@ -256,7 +256,7 @@ func TestPluginSync(t *testing.T) {
 		},
 	}
 	res = c.POST("/v1/routes").WithJSON(route).Expect()
-	res.Status(201)
+	res.Status(http.StatusCreated)
 
 	consumer := &v1.Consumer{
 		Id:       uuid.NewString(),
@@ -265,7 +265,7 @@ func TestPluginSync(t *testing.T) {
 	// create the consumer in CP
 	c = httpexpect.New(t, "http://localhost:3000")
 	res = c.POST("/v1/consumers").WithJSON(consumer).Expect()
-	res.Status(201)
+	res.Status(http.StatusCreated)
 
 	var expectedPlugins []*v1.Plugin
 	plugin := &v1.Plugin{
@@ -277,7 +277,7 @@ func TestPluginSync(t *testing.T) {
 	pluginBytes, err := json.Marshal(plugin)
 	require.Nil(t, err)
 	res = c.POST("/v1/plugins").WithBytes(pluginBytes).Expect()
-	res.Status(201)
+	res.Status(http.StatusCreated)
 	expectedPlugins = append(expectedPlugins, plugin)
 
 	plugin = &v1.Plugin{
@@ -289,7 +289,7 @@ func TestPluginSync(t *testing.T) {
 	pluginBytes, err = json.Marshal(plugin)
 	require.Nil(t, err)
 	res = c.POST("/v1/plugins").WithBytes(pluginBytes).Expect()
-	res.Status(201)
+	res.Status(http.StatusCreated)
 	expectedPlugins = append(expectedPlugins, plugin)
 
 	var config structpb.Struct
@@ -307,7 +307,7 @@ func TestPluginSync(t *testing.T) {
 	pluginBytes, err = json.Marshal(plugin)
 	require.Nil(t, err)
 	res = c.POST("/v1/plugins").WithBytes(pluginBytes).Expect()
-	res.Status(201)
+	res.Status(http.StatusCreated)
 	expectedPlugins = append(expectedPlugins, plugin)
 
 	plugin = &v1.Plugin{
@@ -318,7 +318,7 @@ func TestPluginSync(t *testing.T) {
 	pluginBytes, err = json.Marshal(plugin)
 	require.Nil(t, err)
 	res = c.POST("/v1/plugins").WithBytes(pluginBytes).Expect()
-	res.Status(201)
+	res.Status(http.StatusCreated)
 	expectedPlugins = append(expectedPlugins, plugin)
 
 	dpCleanup := run.KongDP(kong.GetKongConfForShared())
@@ -350,7 +350,7 @@ func TestUpstreamSync(t *testing.T) {
 	}
 	c := httpexpect.New(t, "http://localhost:3000")
 	res := c.POST("/v1/upstreams").WithJSON(upstream).Expect()
-	res.Status(201)
+	res.Status(http.StatusCreated)
 
 	dpCleanup := run.KongDP(kong.GetKongConfForShared())
 	defer dpCleanup()
@@ -379,7 +379,7 @@ func TestConsumerSync(t *testing.T) {
 	// create the consumer in CP
 	c := httpexpect.New(t, "http://localhost:3000")
 	res := c.POST("/v1/consumers").WithJSON(consumer).Expect()
-	res.Status(201)
+	res.Status(http.StatusCreated)
 
 	// launch the DP
 	dpCleanup := run.KongDP(kong.GetKongConfForShared())
@@ -410,7 +410,7 @@ func TestCertificateSync(t *testing.T) {
 	}
 	c := httpexpect.New(t, "http://localhost:3000")
 	res := c.POST("/v1/certificates").WithJSON(certificate).Expect()
-	res.Status(201)
+	res.Status(http.StatusCreated)
 
 	dpCleanup := run.KongDP(kong.GetKongConfForShared())
 	defer dpCleanup()
@@ -438,7 +438,7 @@ func TestCACertificateSync(t *testing.T) {
 	}
 	c := httpexpect.New(t, "http://localhost:3000")
 	res := c.POST("/v1/ca-certificates").WithJSON(certificate).Expect()
-	res.Status(201)
+	res.Status(http.StatusCreated)
 
 	dpCleanup := run.KongDP(kong.GetKongConfForShared())
 	defer dpCleanup()
@@ -466,7 +466,7 @@ func TestSNISync(t *testing.T) {
 		Key:  string(certs.DefaultSharedKey),
 	}
 	c := httpexpect.New(t, "http://localhost:3000")
-	c.POST("/v1/certificates").WithJSON(certificate).Expect().Status(201)
+	c.POST("/v1/certificates").WithJSON(certificate).Expect().Status(http.StatusCreated)
 
 	sni := &v1.SNI{
 		Id:   uuid.NewString(),
@@ -475,7 +475,7 @@ func TestSNISync(t *testing.T) {
 			Id: certificate.Id,
 		},
 	}
-	c.POST("/v1/snis").WithJSON(sni).Expect().Status(201)
+	c.POST("/v1/snis").WithJSON(sni).Expect().Status(http.StatusCreated)
 
 	dpCleanup := run.KongDP(kong.GetKongConfForShared())
 	defer dpCleanup()
@@ -505,14 +505,14 @@ func TestTargetSync(t *testing.T) {
 	}
 	c := httpexpect.New(t, "http://localhost:3000")
 	res := c.POST("/v1/upstreams").WithJSON(upstream).Expect()
-	res.Status(201)
+	res.Status(http.StatusCreated)
 
 	target := &v1.Target{
 		Target:   "10.0.42.42:8000",
 		Upstream: &v1.Upstream{Id: uid},
 	}
 	res = c.POST("/v1/targets").WithJSON(target).Expect()
-	res.Status(201)
+	res.Status(http.StatusCreated)
 
 	dpCleanup := run.KongDP(kong.GetKongConfForShared())
 	defer dpCleanup()
@@ -539,12 +539,12 @@ func TestServiceSync(t *testing.T) {
 	enabledService := goodService()
 	c := httpexpect.New(t, "http://localhost:3000")
 	res := c.POST("/v1/services").WithJSON(enabledService).Expect()
-	res.Status(201)
+	res.Status(http.StatusCreated)
 
 	disabled, err := json.Marshal(disabledService())
 	require.Nil(t, err)
 	res = c.POST("/v1/services").WithBytes(disabled).Expect()
-	res.Status(201)
+	res.Status(http.StatusCreated)
 
 	dpCleanup := run.KongDP(kong.GetKongConfForShared())
 	defer dpCleanup()
@@ -576,7 +576,7 @@ func TestRouteHeader(t *testing.T) {
 	}
 	c := httpexpect.New(t, "http://localhost:3000")
 	res := c.POST("/v1/services").WithJSON(service).Expect()
-	res.Status(201)
+	res.Status(http.StatusCreated)
 	route := &v1.Route{
 		Name:  "bar",
 		Paths: []string{"/"},
@@ -590,7 +590,7 @@ func TestRouteHeader(t *testing.T) {
 		},
 	}
 	res = c.POST("/v1/routes").WithJSON(route).Expect()
-	res.Status(201)
+	res.Status(http.StatusCreated)
 
 	dpCleanup := run.KongDP(kong.GetKongConfForShared())
 	defer dpCleanup()
@@ -686,7 +686,7 @@ func TestExpectedConfigHash(t *testing.T) {
 	}
 	c := httpexpect.New(t, "http://localhost:3000")
 	res := c.POST("/v1/services").WithJSON(fooService).Expect()
-	res.Status(201)
+	res.Status(http.StatusCreated)
 	fooRoute := &v1.Route{
 		Name:  "bar",
 		Paths: []string{"/"},
@@ -695,7 +695,7 @@ func TestExpectedConfigHash(t *testing.T) {
 		},
 	}
 	res = c.POST("/v1/routes").WithJSON(fooRoute).Expect()
-	res.Status(201)
+	res.Status(http.StatusCreated)
 
 	dpCleanup := run.KongDP(kong.GetKongConfForShared())
 	defer dpCleanup()
@@ -731,7 +731,7 @@ func TestExpectedConfigHash(t *testing.T) {
 	})
 
 	res = c.GET("/v1/expected-config-hash").Expect()
-	res.Status(200)
+	res.Status(http.StatusOK)
 	expectedHash := res.JSON().Object().Value("expected_hash").String().Raw()
 	require.Equal(t, expectedHash, hashFromDPAfterFoo)
 
@@ -744,7 +744,7 @@ func TestExpectedConfigHash(t *testing.T) {
 		Path: "/",
 	}
 	res = c.POST("/v1/services").WithJSON(barService).Expect()
-	res.Status(201)
+	res.Status(http.StatusCreated)
 
 	hashFromDPAfterBar := ""
 	util.WaitFunc(t, func() error {
@@ -761,7 +761,7 @@ func TestExpectedConfigHash(t *testing.T) {
 	})
 
 	res = c.GET("/v1/expected-config-hash").Expect()
-	res.Status(200)
+	res.Status(http.StatusOK)
 	newExpectedHash := res.JSON().Object().Value("expected_hash").String().Raw()
 	require.Equal(t, newExpectedHash, hashFromDPAfterBar)
 
@@ -769,7 +769,7 @@ func TestExpectedConfigHash(t *testing.T) {
 	// previous one
 
 	res = c.DELETE("/v1/services/" + barService.Id).Expect()
-	res.Status(204)
+	res.Status(http.StatusNoContent)
 
 	hashAfterDelete := ""
 	util.WaitFunc(t, func() error {
@@ -786,7 +786,7 @@ func TestExpectedConfigHash(t *testing.T) {
 	})
 
 	res = c.GET("/v1/expected-config-hash").Expect()
-	res.Status(200)
+	res.Status(http.StatusOK)
 	expectedHash = res.JSON().Object().Value("expected_hash").String().Raw()
 	require.Equal(t, expectedHash, hashAfterDelete)
 	require.Equal(t, hashFromDPAfterFoo, hashAfterDelete)

--- a/internal/test/e2e/version_compatibility_test.go
+++ b/internal/test/e2e/version_compatibility_test.go
@@ -5,6 +5,7 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"strings"
 	"testing"
 
@@ -309,7 +310,7 @@ func TestVersionCompatibility(t *testing.T) {
 		pluginBytes, err := json.Marshal(plugin)
 		require.Nil(t, err)
 		res := admin.POST("/v1/plugins").WithBytes(pluginBytes).Expect()
-		res.Status(201)
+		res.Status(http.StatusCreated)
 	}
 
 	util.WaitFunc(t, func() error {


### PR DESCRIPTION
Per a [comment that was left in another PR](https://github.com/Kong/koko/pull/183#discussion_r861564416), this simply updates most uses of hard-coded HTTP status code integers to their proper constant values. The uses that were purposefully left are those defined in our [upstream file](https://github.com/Kong/koko/blob/main/internal/resource/upstream.go). As such, this change is only scoped to our tests.

This will at least allow us to remain consistent moving forward.