### PR TITLE
chore: separate out buf-breaking from lint

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -25,3 +25,5 @@ jobs:
       run: make gen-verify
     - name: make lint
       run: make lint
+    - name: make buf-breaking
+      run: make buf-breaking

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ run:
 	go run main.go serve
 
 .PHONY: lint
-lint: buf-breaking
+lint:
 	buf format -d --exit-code
 	buf lint
 	./bin/golangci-lint run ./...


### PR DESCRIPTION
`make lint` and `make test` are considered
core and most often used parts of a developer's workflow.
Fetching from remote and running breaking change detection in those
workflow is too slow for a good development experience.
Also, considering that the likelihood a breaking change detected due to
a change in code is likely small and less relevant in a local workflow
as compared to CI.