### PR TITLE
feat: add method to set global log level

### DIFF
--- a/internal/log/logger.go
+++ b/internal/log/logger.go
@@ -9,6 +9,7 @@ import (
 
 // Logger is setup on startup by cmd package.
 var Logger *zap.Logger
+var zapConfig zap.Config
 
 func init() {
 	// initialized only for testing purposes.
@@ -17,7 +18,7 @@ func init() {
 
 // SetupLogging configure parent logger with logLevel.
 func SetupLogging(logLevel string) (*zap.Logger, error) {
-	zapConfig := zap.NewProductionConfig()
+	zapConfig = zap.NewProductionConfig()
 	zapConfig.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
 	level, err := zapcore.ParseLevel(logLevel)
 	if err != nil {
@@ -30,4 +31,15 @@ func SetupLogging(logLevel string) (*zap.Logger, error) {
 	}
 	Logger = logger
 	return logger, nil
+}
+
+// SetLevel updates the level for the global logger config.
+// All child loggers generated with the config are updated.
+func SetLevel(level string) error {
+	parsedLevel, err := zapcore.ParseLevel(level)
+	if err != nil {
+		return fmt.Errorf("set log level: %w", err)
+	}
+	zapConfig.Level.SetLevel(parsedLevel)
+	return nil
 }

--- a/internal/log/logger_test.go
+++ b/internal/log/logger_test.go
@@ -1,0 +1,66 @@
+package log
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+func TestLogger(t *testing.T) {
+	logger, err := SetupLogging("debug")
+	require.Nil(t, err)
+	require.True(t, zapConfig.Level.Enabled(zap.DebugLevel))
+	require.True(t, logger.Core().Enabled(zapcore.DebugLevel))
+
+	childLogger := logger.With(zap.String("component", "child-logger"))
+	require.True(t, childLogger.Core().Enabled(zapcore.DebugLevel))
+
+	t.Run("SetLevel sets level with valid input", func(t *testing.T) {
+		err := SetLevel("info")
+		require.NoError(t, err)
+		require.True(t, zapConfig.Level.Enabled(zap.InfoLevel))
+		require.False(t, logger.Core().Enabled(zapcore.DebugLevel))
+		require.True(t, logger.Core().Enabled(zapcore.InfoLevel))
+	})
+
+	t.Run("SetLevel is case insensitive", func(t *testing.T) {
+		err := SetLevel("WARN")
+		require.NoError(t, err)
+		require.False(t, zapConfig.Level.Enabled(zap.InfoLevel))
+		require.False(t, logger.Core().Enabled(zapcore.InfoLevel))
+		require.True(t, logger.Core().Enabled(zapcore.WarnLevel))
+	})
+
+	t.Run("SetLevel returns error with invalid input", func(t *testing.T) {
+		err := SetLevel("banana")
+		require.Error(t, err)
+		require.False(t, zapConfig.Level.Enabled(zap.DebugLevel))
+		require.False(t, logger.Core().Enabled(zapcore.InfoLevel))
+	})
+
+	t.Run("SetLevel defaults to 'info' with empty string", func(t *testing.T) {
+		err := SetLevel("")
+		require.NoError(t, err)
+		require.False(t, logger.Core().Enabled(zapcore.DebugLevel))
+		require.True(t, logger.Core().Enabled(zapcore.InfoLevel))
+		require.True(t, logger.Core().Enabled(zapcore.WarnLevel))
+	})
+
+	t.Run("SetLevel effects child loggers", func(t *testing.T) {
+		err := SetLevel("info")
+		require.NoError(t, err)
+		require.False(t, zapConfig.Level.Enabled(zap.DebugLevel))
+		require.True(t, zapConfig.Level.Enabled(zap.InfoLevel))
+		require.False(t, childLogger.Core().Enabled(zapcore.DebugLevel))
+		require.True(t, childLogger.Core().Enabled(zapcore.InfoLevel))
+
+		err = SetLevel("warn")
+		require.NoError(t, err)
+		require.False(t, zapConfig.Level.Enabled(zap.InfoLevel))
+		require.True(t, zapConfig.Level.Enabled(zap.WarnLevel))
+		require.False(t, childLogger.Core().Enabled(zapcore.InfoLevel))
+		require.True(t, childLogger.Core().Enabled(zapcore.WarnLevel))
+	})
+}


### PR DESCRIPTION
# Summary
Makes changes to the logger config so that it can be configured at runtime. Note that log level will return to the default on restart.

- Changes to the global logger config impact all child loggers.
- Adds a method to set the logging level on the global logging config.
- Adds tests for the logger to the test suite.

## Testing
Tested locally via implementing an endpoint that accepts log level inputs and updates the global log level. I specifically checked that the log level update is enforced across the boundaries of the various servers stood up on `Run()`.