### PR TITLE
fix: syncing upstream client certificate to data plane

### DIFF
--- a/internal/server/kong/ws/config/upstream.go
+++ b/internal/server/kong/ws/config/upstream.go
@@ -45,6 +45,7 @@ func (l *KongUpstreamLoader) Mutate(ctx context.Context,
 			return err
 		}
 		flattenForeign(m, "service")
+		flattenForeign(m, "client_certificate")
 		delete(m, "updated_at")
 		res = append(res, m)
 	}


### PR DESCRIPTION
After #194 was introduced, we also realized we were not properly syncing the upstream client certificate ID to the data plane. This change corrects that behavior and implements an E2E test for it.