### PR TITLE
fix: add panic recovery handler/interceptor

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,8 @@ require (
 	github.com/golang/protobuf v1.5.2
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/websocket v1.5.0
-	github.com/grpc-ecosystem/grpc-gateway/v2 v2.10.1
+	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
+	github.com/grpc-ecosystem/grpc-gateway/v2 v2.10.0
 	github.com/hbagdi/gang v0.1.0
 	github.com/imdario/mergo v0.3.12
 	github.com/jeremywohl/flatten v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -589,8 +589,8 @@ github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.7 h1:81/ik6ipDQS2aGcBfIN5dHDB36BwrStyeAQquSYCV4o=
 github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
-github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 github.com/google/go-containerregistry v0.5.1/go.mod h1:Ct15B4yir3PLOP5jsy0GNeYVaIZs/MK/Jz5any1wFW0=
 github.com/google/go-github/v39 v39.2.0/go.mod h1:C1s8C5aCC9L+JXIYpJM5GYytdX52vC1bLvHEF1IhBrE=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
@@ -646,13 +646,14 @@ github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/ad
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
+github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 h1:+9834+KizmvFV7pXQGSXQTsaWhq2GjuNUt0aUU0YBYw=
 github.com/grpc-ecosystem/go-grpc-middleware v1.3.0/go.mod h1:z0ButlSOZa5vEBq9m2m2hlwIgKw+rp3sdCBRoJY+30Y=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
-github.com/grpc-ecosystem/grpc-gateway/v2 v2.10.1 h1:Y7pyy1viWfoKMUVxmjfI5X6fVLlen75kdYjeIwl9CKc=
-github.com/grpc-ecosystem/grpc-gateway/v2 v2.10.1/go.mod h1:chrfS3YoLAlKTRE5cFWvCbt8uGAjshktT4PveTUpsFQ=
+github.com/grpc-ecosystem/grpc-gateway/v2 v2.10.0 h1:ESEyqQqXXFIcImj/BE8oKEX37Zsuceb2cZI+EL/zNCY=
+github.com/grpc-ecosystem/grpc-gateway/v2 v2.10.0/go.mod h1:XnLCLFp3tjoZJszVKjfpyAK6J8sYIcQXWQxmqLWF21I=
 github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed/go.mod h1:tMWxXQ9wFIaZeTI9F+hmhFiGpFmhOHzyShyFUhRm0H4=
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=
 github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
@@ -1688,6 +1689,7 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20220411194840-2f41105eb62f h1:GGU+dLjvlC3qDwqYgL6UgRmHXhOOgns0bZu2Ty5mm6U=
 gonum.org/v1/gonum v0.0.0-20180816165407-929014505bf4/go.mod h1:Y+Yx5eoAFn32cQvJDxZx5Dpnq+c3wtXuadVZAcxbbBo=
 gonum.org/v1/gonum v0.8.2/go.mod h1:oe/vMfY3deqTw+1EZJhuvEW2iwGF1bW9wwu7XCu0+v0=
 gonum.org/v1/gonum v0.9.3/go.mod h1:TZumC3NeyVQskjXqmyWt4S3bINhy7B4eYwW69EbyX+0=

--- a/internal/server/admin/helpers_test.go
+++ b/internal/server/admin/helpers_test.go
@@ -52,7 +52,8 @@ func setupWithDB(t *testing.T, store store.Store) (*httptest.Server, func()) {
 		t.Fatalf("creating httptest.Server: %v", err)
 	}
 
-	s := httptest.NewServer(serverUtil.HandlerWithLogger(handler, log.Logger))
+	h := serverUtil.HandlerWithRecovery(serverUtil.HandlerWithLogger(handler, log.Logger), log.Logger)
+	s := httptest.NewServer(h)
 	return s, func() {
 		s.Close()
 	}

--- a/internal/server/admin/node_test.go
+++ b/internal/server/admin/node_test.go
@@ -50,7 +50,9 @@ func TestNodeCreateUpsert(t *testing.T) {
 	}
 
 	l := setupBufConn()
-	grpcServer := grpc.NewServer(grpc.ChainUnaryInterceptor(serverUtil.LoggerInterceptor(log.Logger)))
+	grpcServer := grpc.NewServer(grpc.ChainUnaryInterceptor(
+		serverUtil.LoggerInterceptor(log.Logger),
+		serverUtil.PanicInterceptor(log.Logger)))
 	service.RegisterNodeServiceServer(grpcServer, nodeService)
 	cc := clientConn(t, l)
 
@@ -137,7 +139,9 @@ func TestNodeDelete(t *testing.T) {
 	}
 
 	l := setupBufConn()
-	grpcServer := grpc.NewServer(grpc.ChainUnaryInterceptor(serverUtil.LoggerInterceptor(log.Logger)))
+	grpcServer := grpc.NewServer(grpc.ChainUnaryInterceptor(
+		serverUtil.LoggerInterceptor(log.Logger),
+		serverUtil.PanicInterceptor(log.Logger)))
 	service.RegisterNodeServiceServer(grpcServer, nodeService)
 	cc := clientConn(t, l)
 
@@ -163,7 +167,7 @@ func TestNodeDelete(t *testing.T) {
 		Validator: validator,
 	})
 	require.Nil(t, err)
-	handler = serverUtil.HandlerWithLogger(handler, log.Logger)
+	handler = serverUtil.HandlerWithRecovery(serverUtil.HandlerWithLogger(handler, log.Logger), log.Logger)
 
 	s := httptest.NewServer(handler)
 	defer s.Close()
@@ -196,7 +200,9 @@ func TestNodeRead(t *testing.T) {
 	}
 
 	l := setupBufConn()
-	grpcServer := grpc.NewServer(grpc.ChainUnaryInterceptor(serverUtil.LoggerInterceptor(log.Logger)))
+	grpcServer := grpc.NewServer(grpc.ChainUnaryInterceptor(
+		serverUtil.LoggerInterceptor(log.Logger),
+		serverUtil.PanicInterceptor(log.Logger)))
 	service.RegisterNodeServiceServer(grpcServer, nodeService)
 	cc := clientConn(t, l)
 
@@ -222,7 +228,7 @@ func TestNodeRead(t *testing.T) {
 		Validator: validator,
 	})
 	require.Nil(t, err)
-	handler = serverUtil.HandlerWithLogger(handler, log.Logger)
+	handler = serverUtil.HandlerWithRecovery(serverUtil.HandlerWithLogger(handler, log.Logger), log.Logger)
 
 	s := httptest.NewServer(handler)
 	defer s.Close()
@@ -261,7 +267,9 @@ func TestNodeList(t *testing.T) {
 	}
 
 	l := setupBufConn()
-	grpcServer := grpc.NewServer(grpc.ChainUnaryInterceptor(serverUtil.LoggerInterceptor(log.Logger)))
+	grpcServer := grpc.NewServer(grpc.ChainUnaryInterceptor(
+		serverUtil.LoggerInterceptor(log.Logger),
+		serverUtil.PanicInterceptor(log.Logger)))
 	service.RegisterNodeServiceServer(grpcServer, nodeService)
 	cc := clientConn(t, l)
 
@@ -298,7 +306,7 @@ func TestNodeList(t *testing.T) {
 		Validator: validator,
 	})
 	require.Nil(t, err)
-	handler = serverUtil.HandlerWithLogger(handler, log.Logger)
+	handler = serverUtil.HandlerWithRecovery(serverUtil.HandlerWithLogger(handler, log.Logger), log.Logger)
 
 	s := httptest.NewServer(handler)
 	defer s.Close()

--- a/internal/server/relay/event_service_test.go
+++ b/internal/server/relay/event_service_test.go
@@ -32,7 +32,11 @@ func TestEventService(t *testing.T) {
 	server := NewEventService(ctx, opts)
 	require.NotNil(t, server)
 	l := setup()
-	s := grpc.NewServer(grpc.ChainUnaryInterceptor(serverUtil.LoggerInterceptor(log.Logger)))
+	grpcServOpts := []grpc.ServerOption{
+		grpc.ChainUnaryInterceptor(serverUtil.LoggerInterceptor(opts.Logger), serverUtil.PanicInterceptor(opts.Logger)),
+		grpc.ChainStreamInterceptor(serverUtil.PanicStreamInterceptor(opts.Logger)),
+	}
+	s := grpc.NewServer(grpcServOpts...)
 	relay.RegisterEventServiceServer(s, server)
 	cc := clientConn(t, l)
 	client := relay.NewEventServiceClient(cc)

--- a/internal/server/relay/status_service_test.go
+++ b/internal/server/relay/status_service_test.go
@@ -29,7 +29,9 @@ func TestRelayStatusServiceUpdate(t *testing.T) {
 	server := NewStatusService(opts)
 	require.NotNil(t, server)
 	l := setup()
-	s := grpc.NewServer(grpc.ChainUnaryInterceptor(serverUtil.LoggerInterceptor(opts.Logger)))
+	s := grpc.NewServer(grpc.ChainUnaryInterceptor(
+		serverUtil.LoggerInterceptor(opts.Logger),
+		serverUtil.PanicInterceptor(opts.Logger)))
 	relay.RegisterStatusServiceServer(s, server)
 	cc := clientConn(t, l)
 	client := relay.NewStatusServiceClient(cc)
@@ -217,7 +219,9 @@ func TestRelayStatusServiceClear(t *testing.T) {
 	server := NewStatusService(opts)
 	require.NotNil(t, server)
 	l := setup()
-	s := grpc.NewServer(grpc.ChainUnaryInterceptor(serverUtil.LoggerInterceptor(opts.Logger)))
+	s := grpc.NewServer(grpc.ChainUnaryInterceptor(
+		serverUtil.LoggerInterceptor(opts.Logger),
+		serverUtil.PanicInterceptor(opts.Logger)))
 	relay.RegisterStatusServiceServer(s, server)
 	cc := clientConn(t, l)
 	client := relay.NewStatusServiceClient(cc)

--- a/internal/server/util/helpers_test.go
+++ b/internal/server/util/helpers_test.go
@@ -1,0 +1,134 @@
+package util
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gavv/httpexpect/v2"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
+)
+
+func TestHandlerWithRecovery(t *testing.T) {
+	t.Run("gracefully handles panics", func(t *testing.T) {
+		l, err := zap.NewProduction()
+		require.NoError(t, err)
+		s := httptest.NewServer(HandlerWithRecovery(thisWillPanic(), l))
+		defer s.Close()
+		c := httpexpect.New(t, s.URL)
+		res := c.POST("/v1/resource/id").WithHeader("content-type", "application/json").Expect()
+		res.Status(http.StatusInternalServerError)
+		res.ContentType("application/json")
+		require.Equal(t, `{"message":"internal server error"}`, res.Body().Raw())
+	})
+}
+
+func thisWillPanic() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		panic(errors.New("something bad happened"))
+	})
+}
+
+func TestPanicInterceptor(t *testing.T) {
+	logger, err := zap.NewProduction()
+	require.NoError(t, err)
+	serverOpts := []grpc.ServerOption{
+		grpc.ChainUnaryInterceptor(LoggerInterceptor(logger), PanicInterceptor(logger)),
+		grpc.ChainStreamInterceptor(PanicStreamInterceptor(logger)),
+	}
+	grpcServer := grpc.NewServer(serverOpts...)
+
+	desc := &grpc.ServiceDesc{
+		ServiceName: "TestService",
+		HandlerType: (*TestServiceServer)(nil),
+		Methods: []grpc.MethodDesc{
+			{
+				MethodName: "PanicTest",
+				Handler:    panicTestHandler,
+			},
+		},
+		Streams: []grpc.StreamDesc{
+			{
+				StreamName:    "PanicStreamTest",
+				Handler:       panicStreamTestHandler,
+				ServerStreams: true,
+				ClientStreams: true,
+			},
+		},
+	}
+	grpcServer.RegisterService(desc, &TestService{})
+	l := setupBufConn()
+	go func() {
+		_ = grpcServer.Serve(l)
+	}()
+	defer grpcServer.Stop()
+	ctx := context.Background()
+
+	t.Run("intercepts panics", func(t *testing.T) {
+		cc := clientConn(ctx, t, l)
+		err := cc.Invoke(ctx, "TestService/PanicTest", nil, nil)
+		require.ErrorContains(t, err, "rpc error: code = Internal desc = internal server error")
+	})
+
+	t.Run("intercepts panics for streams", func(t *testing.T) {
+		cc := clientConn(ctx, t, l)
+		cs, err := cc.NewStream(ctx, &desc.Streams[0], "TestService/PanicStreamTest")
+		require.NoError(t, err)
+		err = cs.RecvMsg(struct{}{})
+		require.ErrorContains(t, err, "rpc error: code = Internal desc = internal server error")
+	})
+}
+
+type TestServiceServer interface {
+	PanicTest() (interface{}, error)
+	PanicStreamTest() error
+}
+
+type TestService struct {
+	grpc.ServerStream
+}
+
+func (ts *TestService) PanicTest() (interface{}, error) {
+	panic(errors.New("something bad happened"))
+}
+
+// nolint:revive // ctx must be second to satisfy interface
+func panicTestHandler(srv interface{}, ctx context.Context, _ func(interface{}) error,
+	interceptor grpc.UnaryServerInterceptor,
+) (interface{}, error) {
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(TestServiceServer).PanicTest()
+	}
+	return interceptor(ctx, struct{}{}, &grpc.UnaryServerInfo{Server: srv}, handler)
+}
+
+func (ts *TestService) PanicStreamTest() error {
+	panic(errors.New("something bad happened"))
+}
+
+func panicStreamTestHandler(srv interface{}, _ grpc.ServerStream) error {
+	return srv.(TestServiceServer).PanicStreamTest()
+}
+
+func setupBufConn() *bufconn.Listener {
+	const bufSize = 1024 * 1024
+	return bufconn.Listen(bufSize)
+}
+
+func clientConn(ctx context.Context, t *testing.T, l *bufconn.Listener) grpc.ClientConnInterface {
+	conn, err := grpc.DialContext(ctx,
+		"bufnet",
+		grpc.WithContextDialer(func(ctx context.Context, s string) (net.Conn, error) {
+			return l.Dial()
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.Nil(t, err)
+	return conn
+}


### PR DESCRIPTION
Adds graceful handling of panics for http + grpc servers.

- Adds a `PanicInterceptor` and `PanicStreamInterceptor` to handle panics without crashing grpc servers
- Both interceptors share the same recovery handler `grpcRecoveryHandler`
- Adds `HandlerWithRecovery` to handle panics without crashing http servers
- All handlers log detailed panic info internally
- End-user will only see limited "recovered from panic" message with 500 internal error code
- Adds a new util test suite to exercise panic recovery

