### PR TITLE
fix: reject POST requests when ID is already present

### DIFF
--- a/internal/resource/plugin_schema.go
+++ b/internal/resource/plugin_schema.go
@@ -87,15 +87,7 @@ func (r PluginSchema) ProcessDefaults() error {
 }
 
 func (r PluginSchema) Indexes() []model.Index {
-	// TODO(fero): remove index for name as the ID when unique fix is added for IDs (bug)
-	return []model.Index{
-		{
-			Name:      "name",
-			Type:      model.IndexUnique,
-			Value:     r.PluginSchema.Name,
-			FieldName: "name",
-		},
-	}
+	return nil
 }
 
 func init() {

--- a/internal/server/admin/plugin_schema_service.go
+++ b/internal/server/admin/plugin_schema_service.go
@@ -31,6 +31,12 @@ func (s *PluginSchemaService) CreateLuaPluginSchema(ctx context.Context,
 	res := resource.NewPluginSchema()
 	res.PluginSchema = req.Item
 	if err := db.Create(ctx, res); err != nil {
+		errConstraint, ok := err.(store.ErrConstraint)
+		if ok {
+			errConstraint.Index.FieldName = "name"
+			errConstraint.Index.Name = "name"
+			err = errConstraint
+		}
 		return nil, s.err(ctx, err)
 	}
 	util.SetHeader(ctx, http.StatusCreated)


### PR DESCRIPTION
The code incorrectly "upserts" on db.Create() calls. This leads to POST
requests allowing for an upsert when the primary key already exists.

This patch fixes the behavior.