### PR TITLE
feat: add ability to configure non-bundled lua plugin schemas

### DIFF
--- a/internal/resource/plugin_schema_test.go
+++ b/internal/resource/plugin_schema_test.go
@@ -1,4 +1,4 @@
-package resource
+package resource_test
 
 import (
 	"context"
@@ -8,30 +8,31 @@ import (
 
 	model "github.com/kong/koko/internal/gen/grpc/kong/admin/model/v1"
 	"github.com/kong/koko/internal/model/json/validation"
+	"github.com/kong/koko/internal/resource"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestNewPluginSchema(t *testing.T) {
-	s := NewPluginSchema()
+	s := resource.NewPluginSchema()
 	require.NotNil(t, s)
 	require.NotNil(t, s.PluginSchema)
 }
 
 func TestPluginSchema_ID(t *testing.T) {
-	var s PluginSchema
+	var s resource.PluginSchema
 	require.Empty(t, s.ID())
 
-	s = NewPluginSchema()
+	s = resource.NewPluginSchema()
 	require.Equal(t, "", s.ID())
 
-	s = NewPluginSchema()
+	s = resource.NewPluginSchema()
 	s.PluginSchema.Name = "plugin-schema-name"
 	require.Equal(t, "plugin-schema-name", s.ID())
 }
 
 func TestPluginSchema_Type(t *testing.T) {
-	require.Equal(t, TypePluginSchema, NewPluginSchema().Type())
+	require.Equal(t, resource.TypePluginSchema, resource.NewPluginSchema().Type())
 }
 
 const pluginSchemaFormat = `return {
@@ -53,7 +54,7 @@ func goodPluginSchema(name string) string {
 
 func TestPluginSchema_ProcessDefaults(t *testing.T) {
 	t.Run("no errors occur when defaults are processed", func(t *testing.T) {
-		r := PluginSchema{
+		r := resource.PluginSchema{
 			PluginSchema: &model.PluginSchema{},
 		}
 		err := r.ProcessDefaults(context.Background())
@@ -63,7 +64,7 @@ func TestPluginSchema_ProcessDefaults(t *testing.T) {
 	})
 
 	t.Run("error occurs with nil schema when processed", func(t *testing.T) {
-		r := PluginSchema{}
+		r := resource.PluginSchema{}
 		err := r.ProcessDefaults(context.Background())
 		require.NotNil(t, err)
 		require.EqualError(t, err, "invalid nil resource")
@@ -74,15 +75,15 @@ func TestPluginSchema_Validate(t *testing.T) {
 	setupLuaValidator(t)
 	tests := []struct {
 		name               string
-		pluginSchema       func() PluginSchema
+		pluginSchema       func() resource.PluginSchema
 		wantErr            bool
 		expectedPluginName string
 		expectedErrs       []*model.ErrorDetail
 	}{
 		{
 			name: "missing plugin schema throws an error",
-			pluginSchema: func() PluginSchema {
-				return NewPluginSchema()
+			pluginSchema: func() resource.PluginSchema {
+				return resource.NewPluginSchema()
 			},
 			wantErr: true,
 			expectedErrs: []*model.ErrorDetail{
@@ -94,8 +95,8 @@ func TestPluginSchema_Validate(t *testing.T) {
 		},
 		{
 			name: "empty plugin schema throws an error",
-			pluginSchema: func() PluginSchema {
-				r := NewPluginSchema()
+			pluginSchema: func() resource.PluginSchema {
+				r := resource.NewPluginSchema()
 				r.PluginSchema.LuaSchema = ""
 				_ = r.ProcessDefaults(context.Background())
 				return r
@@ -110,8 +111,8 @@ func TestPluginSchema_Validate(t *testing.T) {
 		},
 		{
 			name: "valid plugin schema doesn't throw any error",
-			pluginSchema: func() PluginSchema {
-				r := NewPluginSchema()
+			pluginSchema: func() resource.PluginSchema {
+				r := resource.NewPluginSchema()
 				r.PluginSchema.LuaSchema = goodPluginSchema("valid-plugin-schema")
 				_ = r.ProcessDefaults(context.Background())
 				return r
@@ -121,8 +122,8 @@ func TestPluginSchema_Validate(t *testing.T) {
 		},
 		{
 			name: "error occurs when plugin name provided doesn't match expected",
-			pluginSchema: func() PluginSchema {
-				r := NewPluginSchema()
+			pluginSchema: func() resource.PluginSchema {
+				r := resource.NewPluginSchema()
 				r.PluginSchema.Name = "mismatch-plugin-name"
 				r.PluginSchema.LuaSchema = goodPluginSchema("valid-plugin-schema")
 				_ = r.ProcessDefaults(context.Background())
@@ -141,8 +142,8 @@ func TestPluginSchema_Validate(t *testing.T) {
 		},
 		{
 			name: "error occurs when invalid schema is validated",
-			pluginSchema: func() PluginSchema {
-				r := NewPluginSchema()
+			pluginSchema: func() resource.PluginSchema {
+				r := resource.NewPluginSchema()
 				r.PluginSchema.LuaSchema = "return {}"
 				_ = r.ProcessDefaults(context.Background())
 				return r
@@ -160,8 +161,8 @@ func TestPluginSchema_Validate(t *testing.T) {
 		},
 		{
 			name: "error occurs when invalid plugin name is derived from schema",
-			pluginSchema: func() PluginSchema {
-				r := NewPluginSchema()
+			pluginSchema: func() resource.PluginSchema {
+				r := resource.NewPluginSchema()
 				r.PluginSchema.LuaSchema = goodPluginSchema("invalid!name")
 				_ = r.ProcessDefaults(context.Background())
 				return r

--- a/internal/server/admin/plugin_service.go
+++ b/internal/server/admin/plugin_service.go
@@ -52,6 +52,7 @@ func (s *PluginService) CreatePlugin(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
+	ctx = context.WithValue(ctx, util.ContextKeyCluster, req.Cluster)
 	res := resource.NewPlugin()
 	res.Plugin = req.Item
 	if err := db.Create(ctx, res); err != nil {
@@ -73,6 +74,7 @@ func (s *PluginService) UpsertPlugin(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
+	ctx = context.WithValue(ctx, util.ContextKeyCluster, req.Cluster)
 	res := resource.NewPlugin()
 	res.Plugin = req.Item
 	if err := db.Upsert(ctx, res); err != nil {

--- a/internal/server/util/store.go
+++ b/internal/server/util/store.go
@@ -14,6 +14,14 @@ type StoreLoadErr struct {
 	Message string
 }
 
+type contextKey int
+
+const (
+	// ContextKeyCluster is the key used to put and retrieve
+	// `*model.RequestCluster` into context.
+	ContextKeyCluster contextKey = iota
+)
+
 func (s StoreLoadErr) Error() string {
 	return fmt.Sprintf("%s (grpc-code: %d)", s.Message, s.Code)
 }


### PR DESCRIPTION
This feature adds the ability to configure non-bundled Lua plugin schemas using the pre-defined `/v1/plugins` endpoint. Full end to end integration tests need to be created; however this was tested locally using v2.8.1 Kong Gateway data plane. Once the plugin schema is added via the `/v1/plugin-schemas/lua` endpoint it can be configured normally. The plugin schema is retrieved from the database, passed to the validator for loading, validating, and unloading of the plugin and plugin schema.