### PR TITLE
fix: store and use Node pointers instead of copies.

### DIFF
--- a/internal/server/kong/ws/node.go
+++ b/internal/server/kong/ws/node.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"regexp"
+	"sync"
 
 	"github.com/gorilla/websocket"
 	"go.uber.org/zap"
@@ -37,6 +38,7 @@ func truncateHash(s32 string) (sum, error) {
 }
 
 type Node struct {
+	lock     sync.RWMutex
 	ID       string
 	Version  string
 	Hostname string
@@ -68,6 +70,9 @@ func (n *Node) readThread() error {
 }
 
 func (n *Node) write(payload []byte, hash sum) error {
+	n.lock.Lock()
+	defer n.lock.Unlock()
+
 	if n.hash == hash {
 		n.logger.With(zap.String("config_hash",
 			hash.String())).Info("hash matched, skipping update")

--- a/internal/server/kong/ws/node_list.go
+++ b/internal/server/kong/ws/node_list.go
@@ -9,7 +9,7 @@ type NodeList struct {
 	nodes sync.Map
 }
 
-func (l *NodeList) Add(node Node) error {
+func (l *NodeList) Add(node *Node) error {
 	remoteAddr := node.conn.RemoteAddr().String()
 	_, loaded := l.nodes.LoadOrStore(remoteAddr, node)
 	if loaded {
@@ -18,7 +18,7 @@ func (l *NodeList) Add(node Node) error {
 	return nil
 }
 
-func (l *NodeList) Remove(node Node) error {
+func (l *NodeList) Remove(node *Node) error {
 	remoteAddr := node.conn.RemoteAddr().String()
 	_, loaded := l.nodes.LoadAndDelete(remoteAddr)
 	if !loaded {
@@ -27,10 +27,10 @@ func (l *NodeList) Remove(node Node) error {
 	return nil
 }
 
-func (l *NodeList) All() []Node {
-	var res []Node
+func (l *NodeList) All() []*Node {
+	var res []*Node
 	l.nodes.Range(func(key, value interface{}) bool {
-		node, ok := value.(Node)
+		node, ok := value.(*Node)
 		if !ok {
 			panic(fmt.Sprintf("expected type %T but got %T", Node{}, value))
 		}

--- a/internal/server/kong/ws/server.go
+++ b/internal/server/kong/ws/server.go
@@ -80,7 +80,7 @@ func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	queryParams := r.URL.Query()
-	node := Node{
+	node := &Node{
 		ID:       queryParams.Get(nodeIDKey),
 		Hostname: queryParams.Get(nodeHostnameKey),
 		Version:  queryParams.Get(nodeVersionKey),


### PR DESCRIPTION
The NodeList object keeps Node object instances, and returns a copy for each use.  Other functions to handle Nodes receive copy parameters too, meaning the Hash parameter isn't updated generally until they hit the database.

This change replaces all these with Node pointers, so there's a single instance for each DP.

That also means the Ping handler asynchronously modifies a shared resource, and thus needs some form of synchronization. 
solutions include:

  1.  a Mutex lock on each node
  2.  RWMutex on each node
  3.  a Mutex lock on each manager
  4.  relegate all modifications to a single goroutine.

Here we use opion 2, an RWMutex on each node, as it should have the lowest contention.  It should be write-locked only during the short time it takes to update the struct field.  The space overhead is 24 bytes on each node.  If that proves too high, switching to a simple Mutex would reduce to 8 bytes on each node and rise contention only for the case where a Ping message is received while a new config is sent to the same DP node.

The lowest space overhead would be a Mutex on each manager, but contention could be very high during a configuration update.  To reduce contention it would be preferable to hold the lock around the whole update loop for all DP nodes.  Ping messages received during that period could be ignored instead of trying to acquire the lock.

A middle point would be to keep a pool of locks in the NodeList and pick one when "lending" a Node.  This would be much more complex, and require "giving it back" instead of just releasing a lock.  Also, the Ping handler could no longer keep a direct reference to the Node and would have to ask for it to the NodeList.

Moving updates to a dedicated goroutine amounts to the same serialization as using a lock.