### PR TITLE
fix: add a gauge add method to the metrics

### DIFF
--- a/internal/metrics/datadog.go
+++ b/internal/metrics/datadog.go
@@ -28,14 +28,14 @@ func newDatadogClient(logger *zap.Logger, agentAddr string) (*datadogClient, err
 
 // Gauge uses Count as the underlying measure for storing metrics.
 // We assume it is okay to limit Gauge to int.
-func (c *datadogClient) Gauge(name string, value float64, tags ...Tag) {
-	if err := c.client.Count(name, int64(value), convertTags(tags...), defaultRate); err != nil {
+func (c *datadogClient) Gauge(name string, value int64, tags ...Tag) {
+	if err := c.client.Count(name, value, convertTags(tags...), defaultRate); err != nil {
 		c.log.With(zap.Error(err)).Error("failed to update gauge", zap.String("name", name))
 	}
 }
 
-func (c *datadogClient) GaugeAdd(name string, value float64, tags ...Tag) {
-	if err := c.client.Count(name, int64(value), convertTags(tags...), defaultRate); err != nil {
+func (c *datadogClient) GaugeAdd(name string, value int64, tags ...Tag) {
+	if err := c.client.Count(name, value, convertTags(tags...), defaultRate); err != nil {
 		c.log.With(zap.Error(err)).Error("failed to update gauge", zap.String("name", name))
 	}
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -18,11 +18,11 @@ type Tag struct {
 
 type metricsClient interface {
 	// Gauge measures the absolute value of a metric at a particular time.
-	Gauge(name string, value float64, tags ...Tag)
+	Gauge(name string, value int64, tags ...Tag)
 
 	// GaugeAdd adds value to the existing measure of a gauge.
 	// It can be used to add or subtract to the existing measure.
-	GaugeAdd(name string, value float64, tags ...Tag)
+	GaugeAdd(name string, value int64, tags ...Tag)
 
 	// Count tracks how many times something happened.
 	Count(name string, value int64, tags ...Tag)
@@ -108,12 +108,12 @@ func prefixMetricName(name string) string {
 }
 
 // Gauge measures the value of a metric at a particular time.
-func Gauge(name string, value float64, tags ...Tag) {
+func Gauge(name string, value int64, tags ...Tag) {
 	activeClient.Gauge(prefixMetricName(name), value, tags...)
 }
 
 // GaugeAdd adds a new measure to a gauge.
-func GaugeAdd(name string, value float64, tags ...Tag) {
+func GaugeAdd(name string, value int64, tags ...Tag) {
 	activeClient.GaugeAdd(prefixMetricName(name), value, tags...)
 }
 

--- a/internal/metrics/noop.go
+++ b/internal/metrics/noop.go
@@ -9,9 +9,9 @@ import (
 
 type noopClient struct{}
 
-func (c noopClient) Gauge(string, float64, ...Tag) {}
+func (c noopClient) Gauge(string, int64, ...Tag) {}
 
-func (c noopClient) GaugeAdd(string, float64, ...Tag) {}
+func (c noopClient) GaugeAdd(string, int64, ...Tag) {}
 
 func (c noopClient) Count(string, int64, ...Tag) {}
 

--- a/internal/metrics/prometheus.go
+++ b/internal/metrics/prometheus.go
@@ -75,27 +75,27 @@ func (c *prometheusClient) getCollector(collectorType collectorType,
 	return collector, nil
 }
 
-func (c *prometheusClient) Gauge(name string, value float64, tags ...Tag) {
+func (c *prometheusClient) Gauge(name string, value int64, tags ...Tag) {
 	collector, err := c.getCollector(gaugeCollector, name, tags...)
 	if err != nil {
 		c.log.With(zap.Error(err)).Error("failed to update gauge")
 		return
 	}
 	if gauge, ok := collector.(*prometheus.GaugeVec); ok {
-		gauge.With(convertToLabels(tags...)).Set(value)
+		gauge.With(convertToLabels(tags...)).Set(float64(value))
 		return
 	}
 	c.log.Error("collector is not a gauge", zap.String("name", name))
 }
 
-func (c *prometheusClient) GaugeAdd(name string, value float64, tags ...Tag) {
+func (c *prometheusClient) GaugeAdd(name string, value int64, tags ...Tag) {
 	collector, err := c.getCollector(gaugeCollector, name, tags...)
 	if err != nil {
 		c.log.With(zap.Error(err)).Error("failed to update gauge")
 		return
 	}
 	if gauge, ok := collector.(*prometheus.GaugeVec); ok {
-		gauge.With(convertToLabels(tags...)).Add(value)
+		gauge.With(convertToLabels(tags...)).Add(float64(value))
 		return
 	}
 	c.log.Error("collector is not a gauge", zap.String("name", name))

--- a/internal/metrics/prometheus_test.go
+++ b/internal/metrics/prometheus_test.go
@@ -46,14 +46,14 @@ func TestPrometheusGuage(t *testing.T) {
 	var wg sync.WaitGroup
 	for i := 0; i < 5; i++ {
 		wg.Add(1)
-		go func(v int) {
+		go func(v int64) {
 			defer wg.Done()
-			client.Gauge("test_gauge", float64(v), Tag{Key: "service", Value: "test"})
-		}(i)
+			client.Gauge("test_gauge", v, Tag{Key: "service", Value: "test"})
+		}(int64(i))
 	}
 	wg.Wait()
 
-	client.Gauge("test_gauge", float64(10), Tag{Key: "service", Value: "test"})
+	client.Gauge("test_gauge", 10, Tag{Key: "service", Value: "test"})
 
 	collector, err := client.getCollector(gaugeCollector, "test_gauge", Tag{Key: "service", Value: "test"})
 	require.Nil(t, err)
@@ -76,14 +76,14 @@ func TestPrometheusGuageAdd(t *testing.T) {
 	var wg sync.WaitGroup
 	for i := 0; i < 5; i++ {
 		wg.Add(1)
-		go func(v int) {
+		go func(v int64) {
 			defer wg.Done()
-			client.GaugeAdd("test_gauge_add", float64(v), Tag{Key: "service", Value: "test_add"})
-		}(i)
+			client.GaugeAdd("test_gauge_add", v, Tag{Key: "service", Value: "test_add"})
+		}(int64(i))
 	}
 	wg.Wait()
 
-	client.GaugeAdd("test_gauge_add", float64(10), Tag{Key: "service", Value: "test_add"})
+	client.GaugeAdd("test_gauge_add", 10, Tag{Key: "service", Value: "test_add"})
 
 	collector, err := client.getCollector(gaugeCollector, "test_gauge_add", Tag{Key: "service", Value: "test_add"})
 	require.Nil(t, err)


### PR DESCRIPTION
add a new GaugeAdd method to the existing metric client, since the Prometheus client supports this. It provides more flexibility to interact with a gauge.  
