### PR TITLE
fix: update node hash only when reported by ping handler

### DIFF
--- a/internal/server/kong/ws/node.go
+++ b/internal/server/kong/ws/node.go
@@ -71,8 +71,8 @@ func (n *Node) readThread() error {
 }
 
 func (n *Node) write(payload []byte, hash sum) error {
-	n.lock.Lock()
-	defer n.lock.Unlock()
+	n.lock.RLock()
+	defer n.lock.RUnlock()
 
 	if n.hash == hash {
 		n.logger.With(zap.String("config_hash",
@@ -87,6 +87,5 @@ func (n *Node) write(payload []byte, hash sum) error {
 		}
 		return err
 	}
-	n.hash = hash
 	return nil
 }


### PR DESCRIPTION
The code wrongly assumes that a successful websocket message write is equivalent
to the node accepting the configuration.
With this change, the hash is only updated once the node receives the
config and reports back the expected hash via a websocket ping message.