### PR TITLE
fix: use Mutex instead of RWMutex

### DIFF
--- a/internal/server/kong/ws/config/config.go
+++ b/internal/server/kong/ws/config/config.go
@@ -25,7 +25,7 @@ type CachedContent struct {
 type Payload struct {
 	content Content
 	cache   map[string]CachedContent
-	mu      sync.RWMutex
+	mu      sync.Mutex
 	vc      VersionCompatibility
 }
 
@@ -45,8 +45,8 @@ func NewPayload(opts PayloadOpts) (*Payload, error) {
 }
 
 func (p *Payload) Payload(versionStr string) (Content, error) {
-	p.mu.RLock()
-	defer p.mu.RUnlock()
+	p.mu.Lock()
+	defer p.mu.Unlock()
 
 	if _, found := p.cache[versionStr]; !found {
 		updatedPayload, err := p.vc.ProcessConfigTableUpdates(versionStr, p.content.CompressedPayload)


### PR DESCRIPTION
Payload() function performs a read on the cache map and on a cache miss,
writes to the cache. The patch corrects the code to use a mutex.