### PR TITLE
fix: init child metrics logger

### DIFF
--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -62,14 +62,15 @@ func Run(ctx context.Context, config ServerConfig) error {
 
 	defer metrics.Close()
 	if config.Metrics.ClientType == metrics.Prometheus.String() {
-		metricsHandler, err := metrics.CreateHandler(logger)
+		metricsLogger := logger.With(zap.String("component", "metrics"))
+		metricsHandler, err := metrics.CreateHandler(metricsLogger)
 		if err != nil {
 			return fmt.Errorf("create metrics handler failure: %w", err)
 		}
 		s, err := server.NewHTTP(server.HTTPOpts{
 			Address: ":9090",
-			Logger:  logger.With(zap.String("component", "metrics")),
-			Handler: serverUtil.HandlerWithRecovery(metricsHandler, logger),
+			Logger:  metricsLogger,
+			Handler: serverUtil.HandlerWithRecovery(metricsHandler, metricsLogger),
 		})
 		if err != nil {
 			return err


### PR DESCRIPTION
This fixes an omission in #209. A new child logger needs to be initialized before being passed to the recovery handler/http server/createHandler. This will maintain consistency for logging across all servers.

See https://github.com/Kong/koko/blob/main/internal/cmd/run.go#L301-L306 for one example comparison.