### PR TITLE
chore: add prealloc linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -41,6 +41,7 @@ linters:
   - nilnil
   - noctx
   - nolintlint
+  - prealloc
   - predeclared
   - promlinter
   - revive
@@ -102,6 +103,9 @@ issues:
   - linters:
       - gofumpt
     path: internal/gen/wrpc
+  - linters:
+      - prealloc
+    path: _test\.go
 linters-settings:
   depguard:
     include-go-root: true

--- a/internal/crypto/pem_certificate.go
+++ b/internal/crypto/pem_certificate.go
@@ -15,7 +15,7 @@ func ParsePEMCert(cert []byte) (*x509.Certificate, error) {
 }
 
 func ParsePEMCerts(certs ...[]byte) ([]*x509.Certificate, error) {
-	var res []*x509.Certificate
+	res := make([]*x509.Certificate, 0, len(certs))
 	for _, cert := range certs {
 		cert, err := ParsePEMCert(cert)
 		if err != nil {

--- a/internal/model/registry.go
+++ b/internal/model/registry.go
@@ -48,7 +48,7 @@ func NewObject(typ Type) (Object, error) {
 }
 
 func AllTypes() []Type {
-	var res []Type
+	res := make([]Type, 0, len(types))
 	for t := range types {
 		res = append(res, t)
 	}

--- a/internal/plugin/validators/lua_validator.go
+++ b/internal/plugin/validators/lua_validator.go
@@ -142,7 +142,7 @@ func entityErr(err interface{}) *model.ErrorDetail {
 		panic(fmt.Sprintf("expected '@entity' key to be []interface{} but got"+
 			" %T", err))
 	}
-	var messages []string
+	messages := make([]string, 0, len(errs))
 	for _, err := range errs {
 		message, ok := err.(string)
 		if !ok {

--- a/internal/server/admin/plugin_schema_test.go
+++ b/internal/server/admin/plugin_schema_test.go
@@ -188,7 +188,7 @@ func TestPluginSchema_List(t *testing.T) {
 	defer cleanup()
 	c := httpexpect.New(t, s.URL)
 
-	var pluginSchemaNames []string
+	pluginSchemaNames := make([]string, 0, 6)
 	for i := 1; i <= 6; i++ {
 		pluginName := fmt.Sprintf("plugin-schema-%d", i)
 		pluginSchemaBytes, err := json.ProtoJSONMarshal(goodPluginSchema(pluginName))

--- a/internal/server/admin/plugin_test.go
+++ b/internal/server/admin/plugin_test.go
@@ -862,8 +862,9 @@ func TestPluginListByConsumer(t *testing.T) {
 		Expect().Status(http.StatusOK).JSON().Object()
 	items := body.Value("items").Array()
 	items.Length().Equal(2)
-	var gotIDs []string
-	for _, item := range items.Iter() {
+	itemArr := items.Iter()
+	gotIDs := make([]string, 0, len(itemArr))
+	for _, item := range itemArr {
 		gotIDs = append(gotIDs, item.Object().Value("id").String().Raw())
 	}
 	require.ElementsMatch(t, []string{PluginIDOne, PluginIDTwo}, gotIDs)
@@ -875,8 +876,9 @@ func TestAvailablePlugins(t *testing.T) {
 
 	c := httpexpect.New(t, s.URL)
 	body := c.GET("/v1/available-plugins").Expect().Status(http.StatusOK).JSON().Object()
-	var actual []string
-	for _, item := range body.Value("names").Array().Iter() {
+	names := body.Value("names").Array().Iter()
+	actual := make([]string, 0, len(names))
+	for _, item := range names {
 		actual = append(actual, item.String().Raw())
 	}
 

--- a/internal/server/kong/ws/manager.go
+++ b/internal/server/kong/ws/manager.go
@@ -515,7 +515,8 @@ func (m *Manager) getPluginList(node *Node) ([]string, error) {
 	if err != nil {
 		return nil, fmt.Errorf("unmarshal basic-info json message: %v", err)
 	}
-	var plugins []string
+
+	plugins := make([]string, 0, len(info.Plugins))
 	for _, p := range info.Plugins {
 		plugins = append(plugins, p.Name)
 	}

--- a/internal/server/kong/ws/manager_test.go
+++ b/internal/server/kong/ws/manager_test.go
@@ -71,7 +71,7 @@ func TestCleanupNodes(t *testing.T) {
 		require.NotNil(t, res)
 	}
 
-	var expectedLiveNodeIDs []string
+	expectedLiveNodeIDs := make([]string, 0, 2)
 	liveNodePing := int32(time.Now().Unix())
 	for i := 0; i < 2; i++ {
 		id := uuid.NewString()


### PR DESCRIPTION
Adds https://github.com/alexkohler/prealloc, a linter for slice preallocation slices, and makes the suggested changes. Based on [the conversation here.](https://github.com/Kong/koko/pull/204#discussion_r871737608)

The linting behavior uses the default configuration, which returns the following suggested changes:
```
internal/crypto/pem_certificate.go:18:2: Consider preallocating `res` (prealloc)
	var res []*x509.Certificate
internal/model/registry.go:51:2: Consider preallocating `res` (prealloc)
	var res []Type
internal/plugin/validators/lua_validator.go:145:2: Consider preallocating `messages` (prealloc)
	var messages []string
internal/server/kong/ws/manager.go:518:2: Consider preallocating `plugins` (prealloc)
	var plugins []string
internal/server/kong/ws/manager_test.go:104:2: Consider preallocating `gotLiveNodeIDs` (prealloc)
	var gotLiveNodeIDs []string
internal/server/admin/plugin_test.go:865:2: Consider preallocating `gotIDs` (prealloc)
	var gotIDs []string
internal/server/admin/plugin_test.go:878:2: Consider preallocating `actual` (prealloc)
	var actual []string
```

We can optionally enable checking in for-loops. I've left this off for now since "generally weirder things happen inside for loops". I did run and fix up the two (trivial) recommendations:
```
internal/server/admin/plugin_schema_test.go:191 Consider preallocating pluginSchemaNames
internal/server/kong/ws/manager_test.go:74 Consider preallocating expectedLiveNodeIDs
```