### PR TITLE
fix: relaxing consumer.username validation

### DIFF
--- a/internal/gen/jsonschema/schemas/consumer.json
+++ b/internal/gen/jsonschema/schemas/consumer.json
@@ -36,7 +36,7 @@
     "username": {
       "maxLength": 128,
       "minLength": 1,
-      "pattern": "^[0-9a-zA-Z.\\-_~]*$",
+      "pattern": "^[0-9a-zA-Z.\\-_~+@]*$",
       "type": "string"
     }
   },

--- a/internal/resource/consumer.go
+++ b/internal/resource/consumer.go
@@ -15,6 +15,7 @@ const (
 	TypeConsumer = model.Type("consumer")
 
 	maxCustomIDLength = 128
+	maxUsernameLength = 128
 )
 
 var customID = &generator.Schema{
@@ -99,8 +100,13 @@ func init() {
 	consumerSchema := &generator.Schema{
 		Type: "object",
 		Properties: map[string]*generator.Schema{
-			"id":         typedefs.ID,
-			"username":   typedefs.Name,
+			"id": typedefs.ID,
+			"username": {
+				Type:      "string",
+				Pattern:   `^[0-9a-zA-Z.\-_~+@]*$`,
+				MinLength: 1,
+				MaxLength: maxUsernameLength,
+			},
 			"created_at": typedefs.UnixEpoch,
 			"updated_at": typedefs.UnixEpoch,
 			"custom_id":  customID,

--- a/internal/resource/consumer_test.go
+++ b/internal/resource/consumer_test.go
@@ -75,7 +75,7 @@ func TestConsumer_Validate(t *testing.T) {
 	t.Run("good consumer with username and no custom_id must pass", func(t *testing.T) {
 		c := NewConsumer()
 		_ = c.ProcessDefaults(context.Background())
-		c.Consumer.Username = "my-company-name"
+		c.Consumer.Username = "john.doe+koko@example.org"
 		err := c.Validate(context.Background())
 		require.NoError(t, err)
 	})


### PR DESCRIPTION
The Kong gateway currently has incredibly light validation for the `username` field on the consumer resource (as of this writing, it allows all unique input). In order to come closer to its implementation, we're relaxing the validation on the Koko side of things, to allow for both `@` & `+` characters.

UTF8 support will come at a later time.
