### PR TITLE
fix: make sure ts is used correctly

### DIFF
--- a/internal/plugin/validators/lua_validator_test.go
+++ b/internal/plugin/validators/lua_validator_test.go
@@ -157,7 +157,7 @@ func TestProcessAutoFields(t *testing.T) {
 		require.NotPanics(t, func() {
 			uuid.MustParse(plugin.Id)
 		})
-		require.LessOrEqual(t, int32(time.Now().Unix()), plugin.CreatedAt)
+		require.LessOrEqual(t, plugin.CreatedAt, int32(time.Now().Unix()))
 		require.True(t, plugin.Enabled.Value)
 		require.ElementsMatch(t, plugin.Protocols,
 			[]string{"http", "https", "grpc", "grpcs"},


### PR DESCRIPTION
Right now a check for CreatedAt is done as part of the
lua_validator test suit. This should check whether the
CreatedAt timestamp is less-or-equals to the current time,
but right now this is actually checking the opposite,
making this test to be quite flaky.

This PR makes sure this check is used correctly.