### PR TITLE
fix: start manager only after an authenticated node is connected

### DIFF
--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -230,6 +230,7 @@ func Run(ctx context.Context, config ServerConfig) error {
 	// setup control server
 	controlLogger := logger.With(zap.String("component", "control-server"))
 	m := ws.NewManager(ws.ManagerOpts{
+		Ctx:                    ctx,
 		Logger:                 controlLogger,
 		DPConfigLoader:         loader,
 		DPVersionCompatibility: vc,

--- a/internal/server/kong/ws/authenticator.go
+++ b/internal/server/kong/ws/authenticator.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"sync"
 	"time"
 )
 
@@ -47,7 +46,6 @@ type Authenticator interface {
 }
 
 type DefaultAuthenticator struct {
-	once    sync.Once
 	Manager *Manager
 	// Context is passed on the Manager.Run.
 	// Use this context to shut down the manager.
@@ -60,9 +58,6 @@ func (d *DefaultAuthenticator) Authenticate(r *http.Request) (*Manager, error) {
 	if err := d.AuthFn(r); err != nil {
 		return nil, err
 	}
-	d.once.Do(func() {
-		go d.Manager.Run(d.Context)
-	})
 	return d.Manager, nil
 }
 


### PR DESCRIPTION
Instead of starting a configuration sync thread after a node request,
start it after an authenticated node has been seen by the control-plane.