### PR TITLE
perf: avoid reconciliation of configuration on DP connect

### DIFF
--- a/internal/server/kong/ws/manager.go
+++ b/internal/server/kong/ws/manager.go
@@ -231,16 +231,6 @@ func (m *Manager) AddNode(node *Node) {
 				Error("remove node")
 		}
 	}()
-
-	// refresh the payload on DP connect
-	go func() {
-		err = m.reconcileKongPayload(context.Background())
-		if err != nil {
-			m.logger.With(zap.Error(err)).
-				Error("reconcile configuration")
-		}
-		m.broadcast()
-	}()
 }
 
 // broadcast sends the most recent configuration to all connected nodes.


### PR DESCRIPTION
This code predates the event-based refresh of configuration.
Refreshing configuration on a DP-connect was done to simplify
configuration refreshes. With the event-stream now, the configuration is
refreshed dynamically.

The stream is set up before a data-plane is tracked (via AddNode()).
This ensures that the payload will be reconcilied as required and a DP
connect event doesn't require a configuration refresh.

Furthermore, a large number of DP connects could cause a large number of
concurrent configuration reconciliation which is undesired and can even
result in an attack vector.