### PR TITLE
fix: push first configuration to node

### DIFF
--- a/internal/server/kong/ws/manager.go
+++ b/internal/server/kong/ws/manager.go
@@ -231,6 +231,7 @@ func (m *Manager) AddNode(node *Node) {
 				Error("remove node")
 		}
 	}()
+	go m.broadcast()
 }
 
 // broadcast sends the most recent configuration to all connected nodes.


### PR DESCRIPTION
If there are no update events after a node joins, it will not receive
any configuration at all.
This was a bug that was introduced in 4c8f56554.

This patch ensures that the manager pushes at least one configuration to
the DP.