### PR TITLE
chore: remove 2.3.x and 2.4.x from integration test matrix

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -8,8 +8,6 @@ jobs:
       matrix:
         experimental: [false]
         kong_image:
-        - 'kong:2.3.3'
-        - 'kong:2.4.1'
         - 'kong:2.5.1'
         - 'kong:2.6.0'
         - 'kong:2.7.0'


### PR DESCRIPTION
2.3.x and 2.4.x are not supported by Koko. This removes those integration test runs from GitHub Actions.