### PR TITLE
perf: fetch events only when a node is connected

### DIFF
--- a/internal/server/kong/ws/manager.go
+++ b/internal/server/kong/ws/manager.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io"
 	"net"
 	"sync"
 	"time"
@@ -52,7 +51,7 @@ func NewManager(opts ManagerOpts) *Manager {
 		panic(err)
 	}
 
-	return &Manager{
+	m := &Manager{
 		ctx:          opts.Ctx,
 		Cluster:      opts.Cluster,
 		configClient: opts.Client,
@@ -62,6 +61,16 @@ func NewManager(opts ManagerOpts) *Manager {
 		nodes:        &NodeList{},
 		config:       opts.Config,
 	}
+	m.streamer = &streamer{
+		Logger:      opts.Logger.With(zap.String("component", "manager-streamer")),
+		EventClient: opts.Client.Event,
+		OnRecvFunc: func() {
+			m.updateEventCount.Add(1)
+		},
+		Cluster: opts.Cluster,
+		Ctx:     opts.Ctx,
+	}
+	return m
 }
 
 type ManagerConfig struct {
@@ -89,6 +98,11 @@ type Manager struct {
 
 	latestExpectedHash string
 	hashMu             sync.RWMutex
+
+	// nodeTrackingMu protects the critical section of node admission and
+	// removal.
+	nodeTrackingMu sync.Mutex
+	streamer       *streamer
 }
 
 func (m *Manager) reqCluster() *model.RequestCluster {
@@ -194,7 +208,7 @@ func nodeLogger(node *Node, logger *zap.Logger) *zap.Logger {
 
 func (m *Manager) AddNode(node *Node) {
 	m.init.Do(func() {
-		go m.run(m.ctx)
+		go m.nodeCleanThread(m.ctx)
 		go m.eventHandlerThread(m.ctx)
 	})
 	loggerWithNode := nodeLogger(node, m.logger)
@@ -217,9 +231,7 @@ func (m *Manager) AddNode(node *Node) {
 		return
 	}
 	m.setupPingHandler(node)
-	if err := m.nodes.Add(node); err != nil {
-		m.logger.With(zap.Error(err)).Error("track node")
-	}
+	m.addNode(node)
 	// spawn a goroutine for each data-plane node that connects.
 	go func() {
 		err := node.readThread()
@@ -228,14 +240,32 @@ func (m *Manager) AddNode(node *Node) {
 				Error("read thread")
 		}
 		// if there are any ws errors, remove the node
-		// TODO(hbagdi): may need more graceful error handling
-		err = m.nodes.Remove(node)
-		if err != nil {
-			loggerWithNode.With(zap.Error(err)).
-				Error("remove node")
-		}
+		m.removeNode(node)
 	}()
 	go m.broadcast()
+}
+
+func (m *Manager) addNode(node *Node) {
+	m.nodeTrackingMu.Lock()
+	defer m.nodeTrackingMu.Unlock()
+	if err := m.nodes.Add(node); err != nil {
+		m.logger.With(zap.Error(err)).Error("track node")
+	}
+	m.streamer.Enable()
+}
+
+func (m *Manager) removeNode(node *Node) {
+	m.nodeTrackingMu.Lock()
+	defer m.nodeTrackingMu.Unlock()
+	// TODO(hbagdi): may need more graceful error handling
+	if err := m.nodes.Remove(node); err != nil {
+		nodeLogger(node, m.logger).With(zap.Error(err)).
+			Error("remove node")
+	}
+	if len(m.nodes.All()) == 0 {
+		m.logger.Info("no nodes connected, disabling stream")
+		m.streamer.Disable()
+	}
 }
 
 // broadcast sends the most recent configuration to all connected nodes.
@@ -309,22 +339,6 @@ func (m *Manager) updateExpectedHash(ctx context.Context, hash string) {
 }
 
 var defaultRequestTimeout = 5 * time.Second
-
-func (m *Manager) run(ctx context.Context) {
-	go m.nodeCleanThread(ctx)
-	for {
-		stream, err := m.setupStream(ctx)
-		if err != nil {
-			m.logger.With(zap.Error(err)).Error("event stream setup failure")
-			return
-		}
-		m.streamUpdateEvents(ctx, stream)
-		if err := ctx.Err(); err != nil {
-			m.logger.Sugar().Errorf("shutting down manager: %v", err)
-			return
-		}
-	}
-}
 
 func (m *Manager) nodeCleanThread(ctx context.Context) {
 	ticker := time.NewTicker(1 * time.Hour)
@@ -417,53 +431,6 @@ func (m *Manager) listNodes(ctx context.Context) ([]*model.Node, error) {
 		page = resp.Page.NextPageNum
 	}
 	return nodes, nil
-}
-
-func (m *Manager) setupStream(ctx context.Context) (relay.
-	EventService_FetchReconfigureEventsClient, error,
-) {
-	var stream relay.EventService_FetchReconfigureEventsClient
-
-	backoffer := newBackOff(ctx, 0) // retry forever
-	err := backoff.RetryNotify(func() error {
-		var err error
-		stream, err = m.configClient.Event.FetchReconfigureEvents(ctx,
-			&relay.FetchReconfigureEventsRequest{
-				Cluster: m.reqCluster(),
-			})
-		// triggers backoff if err != nil
-		return err
-	}, backoffer, func(err error, duration time.Duration) {
-		if err != nil {
-			m.logger.With(
-				zap.Error(err),
-				zap.Duration("retry-in", duration)).
-				Error("failed to setup a stream with relay server, retrying")
-		}
-	})
-	return stream, err
-}
-
-func (m *Manager) streamUpdateEvents(ctx context.Context, stream relay.
-	EventService_FetchReconfigureEventsClient,
-) {
-	m.logger.Debug("start read from event stream")
-	for {
-		up, err := stream.Recv()
-		if err != nil {
-			if err == io.EOF {
-				m.logger.Info("event stream closed")
-			} else {
-				m.logger.With(zap.Error(err)).Error("receive event")
-			}
-			// return on any error, caller will re-establish a stream if needed
-			return
-		}
-		if up != nil {
-			m.logger.Info("reconfigure event received")
-			m.updateEventCount.Add(1)
-		}
-	}
 }
 
 // eventHandlerThread 'watches' updateEventCount and reconciles as well as

--- a/internal/server/kong/ws/streamer.go
+++ b/internal/server/kong/ws/streamer.go
@@ -1,0 +1,133 @@
+package ws
+
+import (
+	"context"
+	"io"
+	"sync"
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
+	v1 "github.com/kong/koko/internal/gen/grpc/kong/admin/model/v1"
+	relay "github.com/kong/koko/internal/gen/grpc/kong/relay/service/v1"
+	"go.uber.org/zap"
+)
+
+// streamer streams events and invokes a callback.
+// All exported functions are thread-safe unless noted otherwise.
+type streamer struct {
+	// EventClient from which to fetch the events
+	EventClient relay.EventServiceClient
+	// OnRecvFunc is the callback invoked for each event.
+	OnRecvFunc func()
+	Cluster    Cluster
+	// Ctx is used to manage the lifetime of background goroutines that
+	// streamer  may invoke.
+	Ctx    context.Context
+	Logger *zap.Logger
+
+	// mu protects the critical section of enablement/disablement.
+	mu            sync.Mutex
+	currentCancel context.CancelFunc
+}
+
+func (s *streamer) setupStream(ctx context.Context) (relay.EventService_FetchReconfigureEventsClient, error) {
+	var (
+		stream    relay.EventService_FetchReconfigureEventsClient
+		backoffer = newBackOff(ctx, 0) // retry forever
+		ctxErr    error
+	)
+	err := backoff.RetryNotify(func() error {
+		var err error
+		stream, err = s.EventClient.FetchReconfigureEvents(ctx,
+			&relay.FetchReconfigureEventsRequest{
+				Cluster: &v1.RequestCluster{Id: s.Cluster.Get()},
+			})
+		if err != nil {
+			if ctx.Err() != nil {
+				ctxErr = err
+				// stop retrying if Ctx is cancelled
+				return nil
+			}
+		}
+		return err
+	}, backoffer, func(err error, duration time.Duration) {
+		if err != nil {
+			s.Logger.With(
+				zap.Error(err),
+				zap.Duration("retry-in", duration)).
+				Error("failed to setup a stream with relay server, retrying")
+		}
+	})
+	if err != nil {
+		s.Logger.Error("failed to setup stream with relay server", zap.Error(err))
+	}
+	return stream, ctxErr
+}
+
+func (s *streamer) streamUpdateEvents(_ context.Context, stream relay.
+	EventService_FetchReconfigureEventsClient,
+) {
+	s.Logger.Debug("start read from event stream")
+	for {
+		updateEvent, err := stream.Recv()
+		if err != nil {
+			if err == io.EOF {
+				s.Logger.Info("event stream closed")
+				return
+			}
+			s.Logger.With(zap.Error(err)).Error("receive event")
+			// return on any error, caller will re-establish a stream if needed
+			return
+		}
+		if updateEvent != nil {
+			s.Logger.Info("reconfigure event received")
+			s.OnRecvFunc()
+		}
+	}
+}
+
+// Enable enables the stream.
+// Calling enable when the stream is already enabled is a no-op.
+func (s *streamer) Enable() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.currentCancel != nil {
+		s.Logger.Info("stream enablement requested, already enabled")
+		return
+	}
+	s.Logger.Info("stream enabled")
+
+	ctx, cancel := context.WithCancel(s.Ctx)
+	s.currentCancel = cancel
+	go func() {
+		for {
+			if err := ctx.Err(); err != nil {
+				s.Logger.Sugar().Errorf("shutting down streamer: %v", err)
+				return
+			}
+			stream, err := s.setupStream(ctx)
+			if err != nil {
+				s.Logger.With(zap.Error(err)).Error("event stream setup failure")
+				continue
+			}
+			s.streamUpdateEvents(ctx, stream)
+		}
+	}()
+}
+
+// Disable disables the stream.
+// Calling disable when stream is already disabled is a no-op.
+func (s *streamer) Disable() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.currentCancel == nil {
+		s.Logger.Info("stream disablement requested, already disabled")
+		return
+	}
+
+	s.Logger.Info("stream disabled")
+	s.currentCancel()
+	s.currentCancel = nil
+}


### PR DESCRIPTION
Previously, update events were fetched once the manager encountered a
node. If the node disconnected, the update events were still fetched,
the configuration was reconciled and cached. This was wasteful if the
manager didn't have any node connected. This can happen frequently if
there are a number of control-plane nodes that are fronted by a
load-balancer.

This commit has a few changes:
- streaming of updates has been pulled out into a new struct `streamer`
- streaming of updates can be disabled or enabled by the manager
- manager no longer runs a dedicated goroutine, goroutine to fetch
  updates is started and stopped as necessary within streamer instead

The overall API of ws.Manager remains unchanged with this patch.