### PR TITLE
feat: configurable logger encoding

### DIFF
--- a/internal/cmd/serve.go
+++ b/internal/cmd/serve.go
@@ -64,7 +64,7 @@ func setup() (initOpts, error) {
 		return initOpts{}, err
 	}
 
-	logger, err := log.SetupLogging(cfg.Log.Level)
+	logger, err := log.SetupLogging(cfg.Log.Level, cfg.Log.Format)
 	if err != nil {
 		return initOpts{}, err
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,6 +17,7 @@ var (
 	defaultConfigYAML = []byte(`
 log:
   level: info
+  format: json
 admin:
   listeners:
   - address: ":3000"

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -1,7 +1,8 @@
 package config
 
 type Log struct {
-	Level string `json:"level,omitempty"`
+	Level  string `json:"level,omitempty"`
+	Format string `json:"format,omitempty"`
 }
 
 type Listener struct {

--- a/internal/log/logger.go
+++ b/internal/log/logger.go
@@ -17,8 +17,9 @@ func init() {
 }
 
 // SetupLogging configure parent logger with logLevel.
-func SetupLogging(logLevel string) (*zap.Logger, error) {
+func SetupLogging(logLevel string, encoding string) (*zap.Logger, error) {
 	zapConfig = zap.NewProductionConfig()
+	zapConfig.Encoding = encoding
 	zapConfig.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
 	level, err := zapcore.ParseLevel(logLevel)
 	if err != nil {

--- a/internal/log/logger_test.go
+++ b/internal/log/logger_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestLogger(t *testing.T) {
-	logger, err := SetupLogging("debug")
+	logger, err := SetupLogging("debug", "json")
 	require.Nil(t, err)
 	require.True(t, zapConfig.Level.Enabled(zap.DebugLevel))
 	require.True(t, logger.Core().Enabled(zapcore.DebugLevel))

--- a/koko.yaml
+++ b/koko.yaml
@@ -1,5 +1,6 @@
 log:
   level: debug
+  format: console
 database:
   dialect: sqlite3
   query_timeout: 5s


### PR DESCRIPTION
This patch also changes the development log encoder to `console` so that
the maintainers don't age prematurely by being forced to read and decode
json-encoded errors.