### PR TITLE
chore: disable lmdb-preview02 integration test

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -12,7 +12,6 @@ jobs:
         - 'kong:2.6.0'
         - 'kong:2.7.0'
         - 'kong:2.8.0'
-        - 'kong/kong:lmdb-preview02'
         include:
           - kong_image: 'kong/kong:latest' # tracks mainline branch of kong/kong
             experimental: true


### PR DESCRIPTION
This is now included in Kong's main branch.