### PR TITLE
refactor: stop clearing status

### DIFF
--- a/internal/server/kong/ws/manager.go
+++ b/internal/server/kong/ws/manager.go
@@ -109,19 +109,6 @@ func (m *Manager) ReadConfig() ManagerConfig {
 
 func (m *Manager) updateNodeStatus(node *Node) {
 	m.writeNode(node)
-	ctx, cancel := context.WithTimeout(context.Background(), defaultRequestTimeout)
-	defer cancel()
-	_, err := m.configClient.Status.ClearStatus(ctx, &relay.ClearStatusRequest{
-		ContextReference: &model.EntityReference{
-			Id:   node.ID,
-			Type: string(resource.TypeNode),
-		},
-		Cluster: m.reqCluster(),
-	})
-	if err != nil {
-		m.logger.Error("failed to clear status", zap.Error(err),
-			zap.String("node-id", node.ID))
-	}
 }
 
 var emptySum sum


### PR DESCRIPTION
Status tracking was a feature that was in progress some time ago but has
stalled since then. No status is being currently populated so clear
status calls can be dropped for now.

Version compat module needs a lot of work before node status can be reliably
tracked.