### PR TITLE
feat: introducing custom JSON resource marshaler on persistence store objects

### DIFF
--- a/internal/model/object.go
+++ b/internal/model/object.go
@@ -27,6 +27,29 @@ type Object interface {
 	SetResource(Resource) error
 }
 
+// ObjectWithResourceDTO defines a model object that may not store the exact JSON-encoded representation of the
+// underlining Protobuf resource in the persistence store. All callers will still work with the underlining Protobuf
+// resource returned by Object.Resource(), however, when it comes time to store/fetch the resource from the persistence
+// store, it will be translated to/from automatically.
+//
+// A practical use-case of this interface is to ensure commonality across JSON keys, in the event such key needs to be
+// indexed. For example, there could be `$.name` key that is an indexed value in the datastore, however on one resource,
+// instead of calling it `name`, it's called `description`. These (un)marhsal methods can then be used to re-write that
+// key to `name` only within the datastore, in order to prevent the need of creating another index.
+//
+// Given the above example, another use-case is such key may be called the same, however, it may be within a nested
+// object, e.g.: `$.metadata.name`. In that case, these (un)marhsal methods can then be used to rewrite that nested
+// `name` field to be stored at the root of the JSON object, in order to take advantage of an already existing index.
+type ObjectWithResourceDTO interface {
+	// MarshalResourceJSON is just like json.Marshaler, but specifically
+	// for marshalling the resource for use in the persistence store.
+	MarshalResourceJSON() ([]byte, error)
+
+	// UnmarshalResourceJSON is just like json.Unmarshaler, but specifically for unmarshalling
+	// a resource's JSON representation outputted by MarshalResourceJSON().
+	UnmarshalResourceJSON([]byte) error
+}
+
 type TypeIndex string
 
 const (

--- a/internal/store/wrapper_test.go
+++ b/internal/store/wrapper_test.go
@@ -1,0 +1,73 @@
+package store
+
+import (
+	"fmt"
+	"testing"
+
+	v1 "github.com/kong/koko/internal/gen/grpc/kong/admin/model/v1"
+	"github.com/kong/koko/internal/json"
+	"github.com/kong/koko/internal/model"
+	"github.com/kong/koko/internal/resource"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+)
+
+type testObjWithResourceDTO struct {
+	model.Object
+	data map[string]interface{}
+}
+
+func (t testObjWithResourceDTO) MarshalResourceJSON() ([]byte, error) {
+	return json.Marshal(t.data)
+}
+
+func (t testObjWithResourceDTO) UnmarshalResourceJSON(b []byte) error {
+	return json.Unmarshal(b, &t.data)
+}
+
+func Test_wrapObject(t *testing.T) {
+	t.Run("marshal with default Protobuf marshaller", func(t *testing.T) {
+		obj := resource.Consumer{Consumer: &v1.Consumer{Username: "test"}}
+		objJSON, err := wrapObject(obj)
+		require.NoError(t, err)
+		assert.JSONEq(
+			t,
+			fmt.Sprintf(`{"type": %d, "object": {"username": "test"}}`, valueTypeObject),
+			string(objJSON),
+		)
+	})
+
+	t.Run("marshal with MarshalResourceJSON()", func(t *testing.T) {
+		obj := testObjWithResourceDTO{
+			data: map[string]interface{}{"key": "value"},
+		}
+		objJSON, err := wrapObject(obj)
+		require.NoError(t, err)
+		assert.JSONEq(
+			t,
+			fmt.Sprintf(`{"type": %d, "object": {"key": "value"}}`, valueTypeObject),
+			string(objJSON),
+		)
+	})
+}
+
+func Test_unwrapObject(t *testing.T) {
+	t.Run("unmarshal with default Protobuf unmarshaller", func(t *testing.T) {
+		obj := resource.NewConsumer()
+		require.NoError(t, unwrapObject(
+			[]byte(fmt.Sprintf(`{"type": %d, "object": {"username": "test"}}`, valueTypeObject)),
+			obj,
+		))
+		assert.True(t, proto.Equal(&v1.Consumer{Username: "test"}, obj.Consumer))
+	})
+
+	t.Run("unmarshal with UnmarshalResourceJSON()", func(t *testing.T) {
+		obj := testObjWithResourceDTO{data: map[string]interface{}{}}
+		require.NoError(t, unwrapObject(
+			[]byte(fmt.Sprintf(`{"type": %d, "object": {"key": "value"}}`, valueTypeObject)),
+			obj,
+		))
+		assert.Equal(t, map[string]interface{}{"key": "value"}, obj.data)
+	})
+}


### PR DESCRIPTION
Currently, there is no way to represent objects within the persistence store other than the JSON-encoded representation of the object's underlining Protobuf resource.

This change introduces the ability to override that behavior, in order to store resources as a custom JSON object, that may diverge from the JSON-encoded representation of the object's underlining Protobuf resource.