### PR TITLE
fix: sync client_certificate as a string

### DIFF
--- a/internal/server/kong/ws/config/service.go
+++ b/internal/server/kong/ws/config/service.go
@@ -49,6 +49,7 @@ func (l *KongServiceLoader) Mutate(ctx context.Context,
 			return err
 		}
 		delete(m, "enabled")
+		flattenForeign(m, "client_certificate")
 		res = append(res, m)
 	}
 	config["services"] = res


### PR DESCRIPTION
All foreign relations references are marshalled as string fields and not
JSON objects. This was already the case for Upstream <-> client cert
but not Service <-> client cert.