### PR TITLE
feat: add 3.0 changes to acme plugin

### DIFF
--- a/internal/plugin/schemas/acme.lua
+++ b/internal/plugin/schemas/acme.lua
@@ -42,8 +42,7 @@ local VAULT_STORAGE_SCHEMA = {
   { token = { type = "string", referenceable = true, }, },
   { tls_verify = { type = "boolean", default = true, }, },
   { tls_server_name = { type = "string" }, },
-  -- TODO: add default = "token", one_of = { "token", "kubernetes" } in 2.8 or 3.0
-  { auth_method = { type = "string" } },
+  { auth_method = { type = "string", default = "token", one_of = { "token", "kubernetes" } } },
   { auth_path =  { type = "string" }, },
   { auth_role =  { type = "string" }, },
   { jwt_path =  { type = "string" }, },

--- a/internal/server/kong/ws/config/compat/plugin_compatibility.go
+++ b/internal/server/kong/ws/config/compat/plugin_compatibility.go
@@ -183,7 +183,7 @@ var PluginConfigTableUpdates = map[uint64][]config.ConfigTableUpdates{
 			},
 		},
 	},
-	2999999999: {
+	3000000000: {
 		{
 			Name:   "opentelemetry",
 			Type:   config.Plugin,
@@ -207,6 +207,13 @@ var PluginConfigTableUpdates = map[uint64][]config.ConfigTableUpdates{
 				"latency_metrics",
 				"bandwidth_metrics",
 				"upstream_health_metrics",
+			},
+		},
+		{
+			Name: "acme",
+			Type: config.Plugin,
+			RemoveFields: []string{
+				"allow_any_domain",
 			},
 		},
 	},

--- a/internal/test/e2e/version_compatibility_test.go
+++ b/internal/test/e2e/version_compatibility_test.go
@@ -58,6 +58,13 @@ func TestVersionCompatibility(t *testing.T) {
 				]
 			}`,
 		},
+		// DP < 2.6
+		//   - remove 'preferred_chain', 'storage_config.vault.auth_method',
+		//     'storage_config.vault.auth_path', 'storage_config.vault.auth_role',
+		//     'storage_config.vault.jwt_path'
+		//
+		// DP < 3.0:
+		//   - remove 'allow_any_domain'
 		{
 			name: "acme",
 			id:   uuid.NewString(),


### PR DESCRIPTION
Regarding the second commit:

This commit adds a default value to the 'auth_method' field
for the acme plugin, as well as defines a pool of acceptable
values ('token' and 'kubernetes') for the said field.
Despite this change may break compatibility with older DPs
(which had no limitation for the values this field can be assigned to),
the [docs](https://github.com/fffonion/lua-resty-acme#vault)
were already specifying 'token' and 'kubernetes' as the only
acceptable values.

For this reason, this commit doesn't apply any further version
compatibility logic to the acme plugin.

@fffonion would you mind stepping in to double-check the above assertion makes sense?

Kong related changes:
- https://github.com/Kong/kong/pull/9047/files#diff-25aed5512e905778adf558ca405a4a15d755d2c8127e4692c05dd6894621df8c
- https://github.com/Kong/kong/pull/8565/files