### PR TITLE
feat: add default to syslog's 'facility.type' field

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/golang-migrate/migrate/v4 v4.15.2
 	github.com/golang/protobuf v1.5.2
 	github.com/google/cel-go v0.12.4
-	github.com/google/go-cmp v0.5.8
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/websocket v1.5.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0


### PR DESCRIPTION
[According to the changes in Kong](https://github.com/Kong/kong/pull/8564/files#diff-c89756a968fca87ebfaf2b116bdc1528d57c1a8b0f8f2c49c5beb4171b1ba64fL76), I believe the code was already setting the default for this field to `user`, so nothing is needed from a version compatibility point of view.

Is it a fair assumption? @fffonion 