### PR TITLE
feat: add clusterID to config params and reports payload

### DIFF
--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -96,7 +96,7 @@ func Run(ctx context.Context, config ServerConfig) error {
 	if err != nil {
 		return fmt.Errorf("failed to register installation: %w", err)
 	}
-	logger.Info("running with cluster-id", zap.String("id", instID))
+	logger.Info("running with installation-id", zap.String("id", instID))
 
 	validator, err := validators.NewLuaValidator(validators.Opts{
 		Logger:      logger,
@@ -240,6 +240,17 @@ func Run(ctx context.Context, config ServerConfig) error {
 			": %w", err)
 	}
 
+	parametersLoader, err := kongConfigWS.NewParametersLoader(instID)
+	if err != nil {
+		return fmt.Errorf("failed to create parameters configuration loader"+
+			": %w", err)
+	}
+	err = loader.Register(parametersLoader)
+	if err != nil {
+		return fmt.Errorf("failed to register parameters configuration loader"+
+			": %w", err)
+	}
+
 	// setup version compatibility processor
 	vcLogger := logger.With(zap.String("component", "version-compatibility"))
 	vc, err := kongConfigWS.NewVersionCompatibilityProcessor(kongConfigWS.VersionCompatibilityOpts{
@@ -367,8 +378,7 @@ func Run(ctx context.Context, config ServerConfig) error {
 		reporter := util.Reporter{
 			Info: util.Info{
 				KokoVersion: info.VERSION,
-				// TODO(hbagdi): replace this with cluster-id
-				ID: uuid.NewString(),
+				ID:          instID,
 			},
 			Logger: logger,
 		}

--- a/internal/server/kong/ws/config/parameters.go
+++ b/internal/server/kong/ws/config/parameters.go
@@ -1,0 +1,35 @@
+package config
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+)
+
+type ParametersLoader struct {
+	ClusterID string
+}
+
+// NewParametersLoader creates a parameters configuration loader. It requires a valid UUID.
+func NewParametersLoader(clusterID string) (*ParametersLoader, error) {
+	// invalid UUID always returned by Parse as 00000000-0000-0000-0000-000000000000
+	if _, err := uuid.Parse(clusterID); err != nil {
+		return nil, err
+	}
+	return &ParametersLoader{
+		ClusterID: clusterID,
+	}, nil
+}
+
+// Name returns the name of the loader.
+func (l ParametersLoader) Name() string {
+	return "parameters"
+}
+
+// Mutate updates the config parameters, a map of key:value pairs.
+func (l *ParametersLoader) Mutate(_ context.Context,
+	_ MutatorOpts, config DataPlaneConfig,
+) error {
+	config["parameters"] = []Map{{"key": "cluster_id", "value": l.ClusterID}}
+	return nil
+}

--- a/internal/server/kong/ws/config/parameters_test.go
+++ b/internal/server/kong/ws/config/parameters_test.go
@@ -1,0 +1,72 @@
+package config
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewParametersLoader(t *testing.T) {
+	type args struct {
+		clusterID string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *ParametersLoader
+		wantErr error
+	}{
+		{
+			name: "creates a new parameters loader",
+			args: args{
+				clusterID: "b9d640b2-8551-498b-8da4-a55278beefb1",
+			},
+			want: &ParametersLoader{
+				ClusterID: "b9d640b2-8551-498b-8da4-a55278beefb1",
+			},
+			wantErr: nil,
+		},
+		{
+			name: "fails when clusterID is not a valid UUID",
+			args: args{
+				clusterID: "not-a-valid-uuid",
+			},
+			want:    nil,
+			wantErr: fmt.Errorf("invalid UUID length: 16"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewParametersLoader(tt.args.clusterID)
+			assert.Equal(t, tt.want, got)
+			if tt.wantErr != nil {
+				assert.EqualError(t, err, tt.wantErr.Error())
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestParametersLoader_Name(t *testing.T) {
+	t.Run("should return correct loader name", func(t *testing.T) {
+		l := ParametersLoader{}
+		assert.Equal(t, "parameters", l.Name())
+	})
+}
+
+func TestParametersLoader_Mutate(t *testing.T) {
+	t.Run("sets cluster_id correctly", func(t *testing.T) {
+		l := &ParametersLoader{
+			ClusterID: "b9d640b2-8551-498b-8da4-a55278beefb1",
+		}
+		expected := []Map{{"key": "cluster_id", "value": "b9d640b2-8551-498b-8da4-a55278beefb1"}}
+		config := DataPlaneConfig{}
+		err := l.Mutate(context.Background(), MutatorOpts{}, config)
+		require.NoError(t, err)
+		require.Equal(t, expected, config["parameters"])
+	})
+}


### PR DESCRIPTION
Adds the clusterID (or installationID) added in https://github.com/Kong/koko/pull/299 to the config parameters and reports payload.

```
// koko setting clusterID on start
info	cmd/run.go:99	running with installation-id	{"id": "440f81a3-d69a-416c-9d3a-be375e43abcd"}

// kong configs
bash-5.1$ cat config.cache.json
{"ca_certificates":{},"parameters":[{"key":"cluster_id","value":"440f81a3-d69a-416c-9d3a-be375e43abcd"}],"_transform":true,"plugins":{},"certificates":{},"consumers":{},"_format_version":"1.1","services":{},"routes":{},"snis":{},"upstreams":{},"targets":{}}
```