### PR TITLE
chore: bump up go to 1.19 and golangci-lint to 1.48

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # [Choice] Go version (use -bullseye variants on local arm64/Apple Silicon): 1, 1.16, 1.17, 1-bullseye, 1.16-bullseye, 1.17-bullseye, 1-buster, 1.16-buster, 1.17-buster
-ARG VARIANT=1.18-bullseye
+ARG VARIANT=1.19-bullseye
 FROM mcr.microsoft.com/vscode/devcontainers/go:0-${VARIANT}
 
 # Install system tools and configure PostgreSQL

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -21,7 +21,7 @@ jobs:
     - name: Setup go
       uses: actions/setup-go@v3
       with:
-        go-version: '1.18'
+        go-version: '1.19'
     - name: Checkout repository
       uses: actions/checkout@v3
     - name: Cache Go modules

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -7,7 +7,7 @@ jobs:
     - name: Setup go
       uses: actions/setup-go@v3
       with:
-        go-version: '1.18'
+        go-version: '1.19'
     - name: Checkout repository
       uses: actions/checkout@v3
     - name: Cache Go modules

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -15,7 +15,7 @@ jobs:
     - name: Setup go
       uses: actions/setup-go@v3
       with:
-        go-version: '1.18'
+        go-version: '1.19'
     - name: Checkout repository
       uses: actions/checkout@v3
     - name: Cache Go modules

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -30,7 +30,6 @@ linters:
   - gosimple
   - govet
   - grouper
-  - ifshort
   - importas
   - ineffassign
   - lll

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18 AS build
+FROM golang:1.19 AS build
 
 WORKDIR /koko
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kong/koko
 
-go 1.18
+go 1.19
 
 require (
 	github.com/DataDog/datadog-go/v5 v5.1.1

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,7 +2,7 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -43,7 +43,7 @@ func Get(filename string) (Config, error) {
 	if filename == "" {
 		return defaultConfig, nil
 	}
-	content, err := ioutil.ReadFile(filepath.Clean(filename))
+	content, err := os.ReadFile(filepath.Clean(filename))
 	if err != nil {
 		return Config{}, fmt.Errorf("reading file '%v': %w", filename, err)
 	}

--- a/internal/gen/grpc/kong/admin/model/v1/pagination.pb.go
+++ b/internal/gen/grpc/kong/admin/model/v1/pagination.pb.go
@@ -33,13 +33,15 @@ type PaginationRequest struct {
 	// following CEL expressions are supported:
 	//
 	// - Matches resources that have `tag1` as any tag:
-	//     - `"tag1" in tags`
+	//   - `"tag1" in tags`
+	//
 	// - Matches all resources that have both `tag1` & `tag2`:
-	//     - `["tag1", "tag2"].all(x, x in tags)`
-	//     - `"tag1" in tags && "tag2" in tags`
+	//   - `["tag1", "tag2"].all(x, x in tags)`
+	//   - `"tag1" in tags && "tag2" in tags`
+	//
 	// - Matches resources that have `tag1` or `tag2`:
-	//     - `["tag1", "tag2"].exists(x, x in tags)`
-	//     - `"tag1" in tags || "tag2" in tags`
+	//   - `["tag1", "tag2"].exists(x, x in tags)`
+	//   - `"tag1" in tags || "tag2" in tags`
 	//
 	// Limitations:
 	// Currently, it is only possible to filter on tags, and supported logical

--- a/internal/gen/grpc/kong/util/v1/data_plane_prereq.pb.go
+++ b/internal/gen/grpc/kong/util/v1/data_plane_prereq.pb.go
@@ -26,6 +26,7 @@ type DataPlanePrerequisite struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to Config:
+	//
 	//	*DataPlanePrerequisite_RequiredPlugins
 	Config isDataPlanePrerequisite_Config `protobuf_oneof:"config"`
 }

--- a/internal/gen/wrpc/kong/services/config/v1/config.pb.go
+++ b/internal/gen/wrpc/kong/services/config/v1/config.pb.go
@@ -256,6 +256,7 @@ type ReportMetadataResponse struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to Response:
+	//
 	//	*ReportMetadataResponse_Ok
 	//	*ReportMetadataResponse_Error
 	Response isReportMetadataResponse_Response `protobuf_oneof:"response"`
@@ -491,7 +492,6 @@ type SyncConfigRequest struct {
 	// in the request.
 	// Version field has no significance outside the context of a single ephemeral
 	// connection between a DP node and a CP node.
-	//
 	Version uint64 `protobuf:"varint,2,opt,name=version,proto3" json:"version,omitempty"`
 	// raw binary hash of the config data.
 	ConfigHash string          `protobuf:"bytes,3,opt,name=config_hash,json=configHash,proto3" json:"config_hash,omitempty"`

--- a/internal/generators/00dir/main.go
+++ b/internal/generators/00dir/main.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
-	"io/ioutil"
 	"log"
 	"os"
 )
@@ -12,6 +11,7 @@ import (
 // This generator generates the directory structure for the gen/jsonschema
 // package. This is done before generating the schemas because if gen/jsonschema
 // package doesn't exist, the jsonschema generator won't compile.
+//
 //go:generate go run main.go
 func main() {
 	genDir := "../../gen"
@@ -32,7 +32,7 @@ func main() {
 
 	embedFilename := "embed.go"
 	filepath := fmt.Sprintf("%s/%s", jsonSchemaDir, embedFilename)
-	err = ioutil.WriteFile(filepath, []byte(embedContent), fs.ModePerm)
+	err = os.WriteFile(filepath, []byte(embedContent), fs.ModePerm)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/internal/generators/01jsonschema/main.go
+++ b/internal/generators/01jsonschema/main.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
-	"io/ioutil"
 	"log"
 	"os"
 
@@ -38,7 +37,7 @@ func main() {
 			log.Fatalln(err)
 		}
 		filepath := fmt.Sprintf("%s/%s.json", schemasDir, name)
-		err = ioutil.WriteFile(filepath, jsonSchema, fs.ModePerm)
+		err = os.WriteFile(filepath, jsonSchema, fs.ModePerm)
 		if err != nil {
 			log.Fatalln(err)
 		}
@@ -46,7 +45,7 @@ func main() {
 
 	embedFilename := "embed.go"
 	filepath := fmt.Sprintf("%s/%s", jsonSchemaDir, embedFilename)
-	err = ioutil.WriteFile(filepath, []byte(embedContent), fs.ModePerm)
+	err = os.WriteFile(filepath, []byte(embedContent), fs.ModePerm)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/internal/persistence/postgres/postgres.go
+++ b/internal/persistence/postgres/postgres.go
@@ -331,7 +331,7 @@ func addFilterToQuery(query sq.SelectBuilder, expr *exprpb.Expr) (sq.SelectBuild
 
 	queryArgs, err := persistence.GetQueryArgsFromExprConstants(tags)
 	if err != nil {
-		return query, nil
+		return query, err
 	}
 
 	// No-op when there are no tags to filter against, to treat it as if there is no filter at all.

--- a/internal/server/kong/ws/authenticator_test.go
+++ b/internal/server/kong/ws/authenticator_test.go
@@ -4,9 +4,9 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
-	"io/ioutil"
 	"net/http"
 	"net/url"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -291,7 +291,7 @@ func TestAuthFnPKITLS(t *testing.T) {
 }
 
 func loadCertFile(filepath string) ([]byte, error) {
-	certPEM, err := ioutil.ReadFile(filepath)
+	certPEM, err := os.ReadFile(filepath)
 	return certPEM, err
 }
 

--- a/internal/server/kong/ws/config/configuration.go
+++ b/internal/server/kong/ws/config/configuration.go
@@ -5,7 +5,7 @@ import (
 	"compress/gzip"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 
 	"github.com/kong/koko/internal/json"
 )
@@ -108,7 +108,7 @@ func UncompressPayload(payload []byte) ([]byte, error) {
 		return nil, err
 	}
 
-	buf, err := ioutil.ReadAll(r)
+	buf, err := io.ReadAll(r)
 	if err != nil {
 		_ = r.Close()
 		return nil, err

--- a/internal/server/kong/ws/config/version_compatibility.go
+++ b/internal/server/kong/ws/config/version_compatibility.go
@@ -51,7 +51,7 @@ func (u UpdateType) String() string {
 	return [...]string{"plugins", "services"}[u]
 }
 
-//nolint: revive
+//nolint:revive
 type ConfigTableFieldUpdate struct {
 	// Field to perform update or delete operation on; if Value is nil or
 	// ValueFromField is empty the field will be removed.
@@ -64,7 +64,7 @@ type ConfigTableFieldUpdate struct {
 	ValueFromField string
 }
 
-//nolint: revive
+//nolint:revive
 type ConfigTableFieldCondition struct {
 	// Field is a top-level or nested field; use dot notation for nested fields.
 	Field string
@@ -75,7 +75,7 @@ type ConfigTableFieldCondition struct {
 	Updates []ConfigTableFieldUpdate
 }
 
-//nolint: revive
+//nolint:revive
 type ConfigTableUpdates struct {
 	// Name is the name of the configuration or field depending on UpdateType.
 	Name string

--- a/internal/server/kong/ws/negotiation_service.go
+++ b/internal/server/kong/ws/negotiation_service.go
@@ -100,16 +100,14 @@ func (n *Negotiator) chooseVersion(requestedServ *model.ServiceRequest) (choice 
 }
 
 // NegotiateServices is the method handler for the only RPC in this service.
-// The response to the client includes:
-//    - information about the node (just the node ID for now).
-//    - for each requested service, it's either
-//      - in the accepted list:
-//        - respond with the version and a description.
-//        - call the registerer object associated with that service/version
-//          to activate the right responses on this specific peer.
-//      - in the rejected list:
-//        - with a message relevant to the reason (unknown or disabled
-//          service, bad versions).
+// The response to the client includes information about the node (only ID
+// currently) and each requested service.
+//
+// For a service in the accepted list, respond with the version and a description and
+// call the registerer object associated with that service/version to activate
+// the right responses on this specific peer.
+// For a service in the rejected list, respond with a message relevant to the reason
+// (unknown or disabled service, bad versions).
 func (n *Negotiator) NegotiateServices(
 	_ context.Context,
 	peer *wrpc.Peer,

--- a/internal/server/kong/ws/relay_event_streamer.go
+++ b/internal/server/kong/ws/relay_event_streamer.go
@@ -134,7 +134,7 @@ func (r *RelayEventStreamer) setupStream(ctx context.Context,
 			if ctx.Err() != nil {
 				ctxErr = err
 				// stop retrying if ctx is cancelled
-				return nil
+				return nil //nolint:nilerr
 			}
 		}
 		return err

--- a/internal/server/util/helpers_test.go
+++ b/internal/server/util/helpers_test.go
@@ -99,7 +99,7 @@ func (ts *TestService) PanicTest() (interface{}, error) {
 	panic(errors.New("something bad happened"))
 }
 
-// nolint:revive // ctx must be second to satisfy interface
+//nolint:revive // ctx must be second to satisfy interface
 func panicTestHandler(srv interface{}, ctx context.Context, _ func(interface{}) error,
 	interceptor grpc.UnaryServerInterceptor,
 ) (interface{}, error) {

--- a/internal/test/seed/resource.go
+++ b/internal/test/seed/resource.go
@@ -22,7 +22,8 @@ import (
 // to define new functions that piggyback off the default behavior.
 //
 // We know the resources are of the proper type, so we're disabling the type assertion linter.
-// nolint:forcetypeassert
+//
+//nolint:forcetypeassert
 var DefaultNewResourceFuncs = map[model.Type]NewResourceFunc{
 	resource.TypeCACertificate: func(_ Seeder, m proto.Message, _ int) error {
 		r := m.(*v1.CACertificate)

--- a/internal/test/seed/seeder.go
+++ b/internal/test/seed/seeder.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"hash/fnv"
-	"io/ioutil"
+	"io"
 	"math/rand"
 	"net/http"
 	"net/http/httputil"
@@ -391,10 +391,11 @@ func (s *seeder) doHTTPRequest(req *http.Request, msg proto.Message) error {
 	if err != nil {
 		return fmt.Errorf("unable to create resource via the API: %w", err)
 	}
+	defer resp.Body.Close()
 
 	// Replace the resource with the API response, as the API can automatically set fields & so
 	// forth. This assumes the `$.item` key contains the created resource in the response.
-	respJSON, err := ioutil.ReadAll(resp.Body)
+	respJSON, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}

--- a/scripts/install-tools.sh
+++ b/scripts/install-tools.sh
@@ -23,7 +23,7 @@ go install "google.golang.org/grpc/cmd/protoc-gen-go-grpc"
 go install "github.com/kong/go-wrpc/cmd/protoc-gen-go-wrpc"
 go install "google.golang.org/protobuf/cmd/protoc-gen-go"
 
-GOLANGCI_LINT_VERSION=v1.47.2
+GOLANGCI_LINT_VERSION=v1.48.0
 curl -sSfL \
   "https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh" \
   | sh -s -- -b bin ${GOLANGCI_LINT_VERSION}


### PR DESCRIPTION
Notable changes:
- gofmt has seen an update due to new doc comments feature in Go 1.19,
  that has pointed out a few changes in doc comments
- ioutil package is deprecated and is not used anymore
- nolint shouldn't have any space
- fixes a bug where error was not being returned