### PR TITLE
chore: pin Go to 1.18

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -21,7 +21,7 @@ jobs:
     - name: Setup go
       uses: actions/setup-go@v3
       with:
-        go-version: '^1.18'
+        go-version: '1.18'
     - name: Checkout repository
       uses: actions/checkout@v3
     - name: Cache Go modules

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -7,7 +7,7 @@ jobs:
     - name: Setup go
       uses: actions/setup-go@v3
       with:
-        go-version: '^1.18'
+        go-version: '1.18'
     - name: Checkout repository
       uses: actions/checkout@v3
     - name: Cache Go modules

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -15,7 +15,7 @@ jobs:
     - name: Setup go
       uses: actions/setup-go@v3
       with:
-        go-version: '^1.18'
+        go-version: '1.18'
     - name: Checkout repository
       uses: actions/checkout@v3
     - name: Cache Go modules


### PR DESCRIPTION
Go is pinned to fetch the latest version above '1.18' instead of pinning
it to latest patch verion of '1.18'.