### PR TITLE
refactor: export custom version parsing function

### DIFF
--- a/internal/server/kong/ws/config/change_metadata.go
+++ b/internal/server/kong/ws/config/change_metadata.go
@@ -89,7 +89,7 @@ func (c *Change) valid() error {
 		return fmt.Errorf("invalid version range '%v'", c.SemverRange)
 	}
 
-	if _, err := semver.ParseRange(c.SemverRange); err != nil {
+	if _, err := semver.ParseRange(translateVersionFormat(c.SemverRange)); err != nil {
 		return fmt.Errorf("invalid range format '%v': %w", c.SemverRange, err)
 	}
 	return nil

--- a/internal/server/kong/ws/config/change_metadata_test.go
+++ b/internal/server/kong/ws/config/change_metadata_test.go
@@ -97,6 +97,19 @@ func TestChange_valid(t *testing.T) {
 		err := change.valid()
 		require.ErrorContains(t, err, "invalid range")
 	})
+	t.Run("change with enterprise version returns no error", func(t *testing.T) {
+		change := Change{
+			Metadata: ChangeMetadata{
+				ID:          "F123",
+				Severity:    ChangeSeverityWarning,
+				Description: "some description",
+				Resolution:  "some resolution",
+			},
+			SemverRange: "< 3.0.0.0",
+		}
+		err := change.valid()
+		require.NoError(t, err)
+	})
 }
 
 func TestCompatChangeRegistryImpl_Register(t *testing.T) {

--- a/internal/server/kong/ws/config/compat/extra_processing.go
+++ b/internal/server/kong/ws/config/compat/extra_processing.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/blang/semver/v4"
+	"github.com/kong/koko/internal/server/kong/ws/config"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 	"go.uber.org/zap"
@@ -99,9 +100,13 @@ func VersionCompatibilityExtraProcessing(payload string, dataPlaneVersion string
 ) (string, error) {
 	processedPayload := payload
 
-	dataPlaneSemVer, err := semver.Parse(dataPlaneVersion)
+	dataPlaneVersionParsed, err := config.ParseSemanticVersion(dataPlaneVersion)
 	if err != nil {
-		return "", fmt.Errorf("could not parse dataplane version %s: %w", dataPlaneVersion, err)
+		return "", fmt.Errorf("invalid data plane version %s: %w", dataPlaneVersion, err)
+	}
+	dataPlaneSemVer, err := semver.Parse(dataPlaneVersionParsed)
+	if err != nil {
+		return "", fmt.Errorf("could not parse data plane version %s: %w", dataPlaneVersion, err)
 	}
 
 	if versionOlderThan300(dataPlaneSemVer) {

--- a/internal/server/kong/ws/config/version_compatibility.go
+++ b/internal/server/kong/ws/config/version_compatibility.go
@@ -125,7 +125,7 @@ func NewVersionCompatibilityProcessor(opts VersionCompatibilityOpts) (*WSVersion
 	if len(strings.TrimSpace(opts.KongCPVersion)) == 0 {
 		return nil, fmt.Errorf("opts.KongCPVersion required")
 	}
-	controlPlaneVersion, err := parseSemanticVersion(opts.KongCPVersion)
+	controlPlaneVersion, err := ParseSemanticVersion(opts.KongCPVersion)
 	if err != nil {
 		return nil, fmt.Errorf("unable to parse opts.KongCPVersion %v", err)
 	}
@@ -159,7 +159,7 @@ func (vc *WSVersionCompatibility) AddConfigTableUpdates(payloadUpdates Versioned
 func (vc *WSVersionCompatibility) ProcessConfigTableUpdates(dataPlaneVersionStr string,
 	compressedPayload []byte,
 ) ([]byte, error) {
-	dataPlaneVersion, err := parseSemanticVersion(dataPlaneVersionStr)
+	dataPlaneVersion, err := ParseSemanticVersion(dataPlaneVersionStr)
 	if err != nil {
 		return nil, fmt.Errorf("unable to parse data plane version: %v", err)
 	}
@@ -270,7 +270,7 @@ func addEnterpriseVersion(version, extra, num string) string {
 	return fmt.Sprintf("%s-%s", version, num)
 }
 
-// parseSemanticVersion parses a data plane version into something that
+// ParseSemanticVersion parses a data plane version into something that
 // follows Koko's convention allowing version ranges to be handled which are not
 // necessarily semver-compliant; this can be a parsing standard semver for the
 // case of a simple X.Y.Z format, but it can handle more expressive version
@@ -288,7 +288,7 @@ func addEnterpriseVersion(version, extra, num string) string {
 //
 // input:  0.33.3.3-enterprise   (enterprise build)
 // output: 0.33.3.3
-func parseSemanticVersion(versionStr string) (string, error) {
+func ParseSemanticVersion(versionStr string) (string, error) {
 	semVersion, err := kong.ParseSemanticVersion(versionStr)
 	if err != nil {
 		return "", err

--- a/internal/server/kong/ws/config/version_compatibility_test.go
+++ b/internal/server/kong/ws/config/version_compatibility_test.go
@@ -145,7 +145,7 @@ func TestVersionCompatibility_ParseSemanticVersion(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		version, err := parseSemanticVersion(test.versionStr)
+		version, err := ParseSemanticVersion(test.versionStr)
 		if test.wantsErr {
 			require.NotNil(t, err)
 			require.EqualError(t, err, test.expectedErr)


### PR DESCRIPTION
Other than exporting the ParseSemanticVersion function,
this PR makes sure version ranges validation takes
into account enterprise versioning as well.