### PR TITLE
tests: allowing for cross-platform E2E tests & more configurability

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/Masterminds/squirrel v1.5.3
 	github.com/blang/semver/v4 v4.0.0
 	github.com/bufbuild/buf v1.7.0
+	github.com/caarlos0/env/v6 v6.9.3
 	github.com/cenkalti/backoff/v4 v4.1.3
 	github.com/cespare/xxhash/v2 v2.1.2
 	github.com/gavv/httpexpect/v2 v2.3.1

--- a/go.sum
+++ b/go.sum
@@ -196,6 +196,8 @@ github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx2
 github.com/bugsnag/bugsnag-go v0.0.0-20141110184014-b1d153021fcd/go.mod h1:2oa8nejYd4cQ/b0hMIopN0lCRxU0bueqREvZLWFrtK8=
 github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b/go.mod h1:obH5gd0BsqsP2LwDJ9aOkm/6J86V6lyAXCoQWGw3K50=
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
+github.com/caarlos0/env/v6 v6.9.3 h1:Tyg69hoVXDnpO5Qvpsu8EoquarbPyQb+YwExWHP8wWU=
+github.com/caarlos0/env/v6 v6.9.3/go.mod h1:hvp/ryKXKipEkcuYjs9mI4bBCg+UI0Yhgm5Zu0ddvwc=
 github.com/cenkalti/backoff/v4 v4.1.1/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/cenkalti/backoff/v4 v4.1.2/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/cenkalti/backoff/v4 v4.1.3 h1:cFAlzYUlVYDysBEH2T5hyJZMh3+5+WCBvSnK6Q8UtC4=

--- a/internal/test/kong/docker.go
+++ b/internal/test/kong/docker.go
@@ -1,0 +1,102 @@
+package kong
+
+const (
+	// On non-Linux systems, this is Docker's hostname that allows routing to the host gateway.
+	// Read more: https://docs.docker.com/desktop/networking/#i-want-to-connect-from-a-container-to-a-service-on-the-host
+	dockerHostGWHostname = "host.docker.internal"
+
+	// Used with `--add-host`, which is Docker's special string to tell it
+	// to re-write it to the host's gateway IP. This is not a hostname.
+	dockerHostGWName = "host-gateway"
+
+	// The `host` networking interface, which binds the container to the host's networking interface on Linux only.
+	// Read more: https://docs.docker.com/network/host
+	dockerHostNetwork = "host"
+)
+
+// Environment variable backing DockerInput.EnableAutoDPEnv.
+const envEnableAutoDPEnv = "KOKO_TEST_ENABLE_AUTO_DP_ENV"
+
+// See DockerInput.EnvVars for usage info.
+var defaultEnvVars = map[string]string{
+	"KONG_CLUSTER_CA_CERT":             fileClusterCACert,
+	"KONG_CLUSTER_CERT":                fileClusterCert,
+	"KONG_CLUSTER_CERT_KEY":            fileClusterKey,
+	"KONG_LUA_SSL_TRUSTED_CERTIFICATE": fileClusterCACert,
+	"KONG_NGINX_HTTP_INCLUDE":          fileAdminConf,
+
+	"KONG_ANONYMOUS_REPORTS":      "off",
+	"KONG_DATABASE":               "off",
+	"KONG_NGINX_WORKER_PROCESSES": "1",
+	"KONG_ROLE":                   "data_plane",
+	"KONG_VITALS":                 "off",
+}
+
+// See dockerInternalInput.Ports for usage info.
+//
+//nolint:gomnd
+var defaultDockerPorts = map[int]int{
+	8000: 8000, // Kong DP HTTP proxy port (`KONG_PROXY_LISTEN`).
+	8001: 8001, // Kong DP HTTP admin API port (`KONG_ADMIN_LISTEN`).
+}
+
+// DockerInput defines the required values in order to spin up a DP via Docker.
+type DockerInput struct {
+	// Internal values that are required for use in Go template generation, but must not be set
+	// by other callers. It is exported to ensure the underlying Go template works as intended.
+	Internal dockerInternalInput
+
+	// Environment variables to be passed to the DP (`-e`/`--env`).
+	EnvVars map[string]string
+
+	// The name of the Docker container created for the DP.
+	ContainerName string `env:"KOKO_TEST_KONG_DP_CONTAINER_NAME" envDefault:"koko-dp"`
+
+	// The Docker image passed to `docker run ... [IMAGE]`.
+	Image string `env:"KOKO_TEST_KONG_DP_IMAGE,notEmpty"`
+
+	// The existing Docker network to attach the DP to (`--network`).
+	Network string `env:"KOKO_TEST_KONG_DP_NETWORK"`
+
+	// When set to true, all `KONG_*` environment variables are passed to the DP
+	// when creating the container, and these override any defaulted values.
+	//
+	// NOTE: Here be dragons enabling this, as Koko may be setting `KONG_*` environment
+	// variables during integration tests, which are used both by Koko itself along with
+	// the DP. An example of this is the `KONG_LICENSE_DATA` environment variable.
+	//
+	// This setting is mostly meant for local development only, and not for use in CI.
+	EnableAutoDPEnv bool `env:"KOKO_TEST_ENABLE_AUTO_DP_ENV"`
+
+	// The address to the control plane.
+	// When not provided, this will automatically be set based on the host OS.
+	CPAddr string `env:"KONG_CLUSTER_CONTROL_PLANE"`
+
+	// The DP cluster certificate contents.
+	ClientCert []byte `env:"KONG_CLUSTER_CERT_RAW"`
+
+	// The DP cluster certificate key contents.
+	ClientKey []byte `env:"KONG_CLUSTER_CERT_KEY_RAW"`
+
+	// The DP cluster CA certificate key contents.
+	CACert []byte `env:"KONG_CLUSTER_CA_CERT_RAW"`
+}
+
+type dockerInternalInput struct {
+	// Sources in environment variables from the Koko process.
+	HostEnvVars map[string]string
+
+	// Volumes to bind mount (`-v`/`--volume`).
+	// (host path)->(container path)
+	//
+	// Host paths are relative to the temp directory that is created on the host system.
+	Volumes map[string]string
+
+	// The host-to-IP mappings that will be created on the container's network interface (`--add-host`).
+	// (hostname)->(IP address)
+	Hosts map[string]string
+
+	// The ports from the container to publish to the host (`-p`/`--publish`).
+	// (Host port)->(Container port)
+	Ports map[int]int
+}

--- a/internal/test/kong/template.go
+++ b/internal/test/kong/template.go
@@ -1,0 +1,76 @@
+package kong
+
+import (
+	"fmt"
+	"strings"
+	"text/template"
+)
+
+var adminServerConf = []byte(`
+server {
+  listen 8001;
+  location / {
+    default_type application/json;
+    content_by_lua_block {
+      Kong.admin_content()
+    }
+    header_filter_by_lua_block {
+      Kong.admin_header_filter()
+    }
+  }
+}
+`)
+
+var scriptTemplate = `#!/bin/bash
+set -e 
+set -x
+cleanup () {
+  echo "interrupt received, exiting now"
+  docker rm -f {{ $.ContainerName }} 
+  exit 0
+}
+DIR=$(dirname "$0")
+trap cleanup INT
+docker run \
+  --rm \
+  --name {{ $.ContainerName }} \
+{{- range $k, $v := $.EnvVars }}
+  -e {{ $k }}={{ sh $v }} \
+{{- end -}}
+{{- range $host, $container := $.Internal.Volumes }}
+  -v "$DIR/{{ $host }}:{{ $container }}" \
+{{- end -}}
+{{- range $host, $container := .Internal.Ports }}
+  -p {{ $host }}:{{ $container }} \
+{{- end -}}
+{{- range $hostname, $ip := .Internal.Hosts }}
+  --add-host {{ $hostname }}:{{ $ip }} \
+{{- end -}}
+{{- if .Network }}
+  --network {{ .Network }} \
+{{- end }}
+  {{ .Image }} &
+wait
+`
+
+var t *template.Template
+
+func init() {
+	t = template.Must(template.New("run").Funcs(template.FuncMap{
+		"sh": shellEscaper,
+	}).Parse(scriptTemplate))
+}
+
+// shellEscaper handles escaping shell input, mostly used for handling of environment variables.
+func shellEscaper(args ...any) (string, error) {
+	if len(args) != 1 {
+		return "", fmt.Errorf("expected a single string as input for shell escape function")
+	}
+
+	s, ok := args[0].(string)
+	if !ok {
+		return "", fmt.Errorf("expected string input for shell escape function, but got %T", args[0])
+	}
+
+	return "'" + strings.ReplaceAll(s, "'", "'\"'\"'") + "'", nil
+}

--- a/internal/test/run/run.go
+++ b/internal/test/run/run.go
@@ -127,7 +127,11 @@ func KongDP(input kong.DockerInput) func() {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		_ = kong.RunDP(ctx, input)
+		if err := kong.RunDP(ctx, input); err != nil {
+			// TODO(tjasko): Update KongDP() function to return an error, to allow callers to properly handle
+			//  the error. Luckily, an error here is usually not expected unless bad input was provided.
+			panic(err)
+		}
 	}()
 	return func() {
 		cancel()


### PR DESCRIPTION
This change allows for the use of Koko's E2E tests to properly run on both Linux & macOS hosts. Additionally, environment variables can be configured in order to alter most defaulted settings.

There is more work to be done here, however, these changes will prevent macOS users from needing to make manual code updates in order to run the E2E tests.

----

Tests have been run against all parts of the codebase to ensure proper compatibility & everything passed as expected.