### PR TITLE
style: introducing EditorConfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+; https://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[{Makefile,go.mod,go.sum,*.go}]
+indent_size = 4
+indent_style = tab
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
Introducing an [EditorConfig](https://editorconfig.org/) file that'll help enforce a few simple things.

This is here to mostly enforce new lines at the end of files, consistent whitespace formatting, and such. The config here is based on our existing Go, YAML, Markdown, etc. files.