### PR TITLE
refactor: bump up _format_version to 2.1

### DIFF
--- a/internal/server/kong/ws/config/version.go
+++ b/internal/server/kong/ws/config/version.go
@@ -13,7 +13,7 @@ func (l VersionLoader) Name() string {
 func (l *VersionLoader) Mutate(_ context.Context,
 	_ MutatorOpts, config DataPlaneConfig,
 ) error {
-	config["_format_version"] = "1.1"
+	config["_format_version"] = "2.1"
 	config["_transform"] = false
 	return nil
 }


### PR DESCRIPTION
Koko is incompatible with Kong Gateway nodes < 2.5.
This is a change that should have no effect on any behavior of DAO
transformation or configuration parsing in data-planes >= 2.5.