### PR TITLE
chore: sync rate-limiting and response-ratelimiting plugins

### DIFF
--- a/internal/plugin/schemas/rate-limiting.lua
+++ b/internal/plugin/schemas/rate-limiting.lua
@@ -44,7 +44,7 @@ if is_dbless() then
 else
   policy = {
     type = "string",
-    default = "cluster",
+    default = "local",
     len_min = 0,
     one_of = {
       "local",

--- a/internal/plugin/schemas/response-ratelimiting.lua
+++ b/internal/plugin/schemas/response-ratelimiting.lua
@@ -43,7 +43,7 @@ if is_dbless() then
 else
   policy = {
     type = "string",
-    default = "cluster",
+    default = "local",
     one_of = {
       "local",
       "cluster",


### PR DESCRIPTION
Updates the default policy from "cluster" to "local" for Kong Gateway OSS
plugins rate-limiting and response-ratelimiting.