### PR TITLE
chore: bump up googleapis commit hash

### DIFF
--- a/internal/grpc/proto/buf.lock
+++ b/internal/grpc/proto/buf.lock
@@ -4,14 +4,8 @@ deps:
   - remote: buf.build
     owner: googleapis
     repository: googleapis
-    branch: main
-    commit: 7cc90235b0b34a33961f2d27162fbfb7
-    digest: b1-7aR1G7jkTCelrf6_GT5R5Y98Qn4OGNiqntQyrbZGTio=
-    create_time: 2022-02-16T15:20:23.829328Z
+    commit: 62f35d8aed1149c291d606d958a7ce32
   - remote: buf.build
     owner: grpc-ecosystem
     repository: grpc-gateway
-    branch: main
-    commit: ff83506eb9cc4cf8972f49ce87e6ed3e
-    digest: b1-iLPHgLaoeWWinMiXXqPnxqE4BThtY3eSbswVGh9GOGI=
-    create_time: 2021-10-23T16:26:52.283938Z
+    commit: bc28b723cd774c32b6fbc77621518765

--- a/internal/wrpc/proto/buf.lock
+++ b/internal/wrpc/proto/buf.lock
@@ -4,7 +4,4 @@ deps:
   - remote: buf.build
     owner: googleapis
     repository: googleapis
-    branch: main
-    commit: c19a273b594646ccb53d16b7ec886a4d
-    digest: b1-BVnM1__D4vEJ1s8523tlB9ePoxZ5MHBYhFyoxoZEZRY=
-    create_time: 2021-09-14T15:04:24.472926Z
+    commit: 62f35d8aed1149c291d606d958a7ce32


### PR DESCRIPTION
It seems like buf registry is trimming the commit SHAs it tracks. The CI is broken because the remote depenedency based on the SHA cannot be found anymore.