### PR TITLE
tests: increase max retries in tests from 30 to 45

### DIFF
--- a/internal/test/util/util.go
+++ b/internal/test/util/util.go
@@ -28,7 +28,7 @@ var (
 )
 
 const (
-	maxRetriesInTests = 30
+	maxRetriesInTests = 45
 	retryTimeout      = 5 * time.Second
 	requestTimeout    = 30 * time.Second
 )


### PR DESCRIPTION
koko integration tests require a DP to be created and
connected to koko CP. Koko rebuilds clusters map every
30 seconds, meaning that a DP connected to koko may remain in
an idle state (not receiving payloads) for up to 30 seconds,
until it gets authenticated.

Right now, koko e2e tests allow a max retry value equals to 30,
(which corresponds to 30 seconds, each retry happening every
1 second) which in some corner cases may be just too little due
to the clusters map rebuild logic mentioned above, causing some
tests to be flaky.

This commit increase the maxRetriesInTests to 45 to avoid such
corner cases.