### PR TITLE
refactor: clean up plugin schema retreival

### DIFF
--- a/internal/plugin/validator.go
+++ b/internal/plugin/validator.go
@@ -26,11 +26,7 @@ type Validator interface {
 	// ascending order. The returned slice must not be modified.
 	GetAvailablePluginNames(ctx context.Context) []string
 
-	// GetRawLuaSchema returns the raw Lua schema for the given plugin. In the event the plugin
-	// does not exist, an error is returned. The returned slice must not be modified.
+	// GetRawLuaSchema returns the raw Lua schema for the given plugin (bundled or non-bundled). In the
+	// event the plugin does not exist, an error is returned. The returned slice must not be modified.
 	GetRawLuaSchema(ctx context.Context, name string) ([]byte, error)
-
-	// GetRawLuaSchemaForCustomPlugin returns the raw Lua schema for the given non-bundled plugin.
-	// In the event the plugin does not exist, an error is returned.
-	GetRawLuaSchemaForCustomPlugin(ctx context.Context, name string) ([]byte, error)
 }

--- a/internal/plugin/validators/lua_validator.go
+++ b/internal/plugin/validators/lua_validator.go
@@ -292,15 +292,13 @@ func (v *LuaValidator) LoadSchemasFromEmbed(fs embed.FS, dirName string) error {
 
 // GetRawLuaSchema implements the Validator.GetRawLuaSchema interface.
 func (v *LuaValidator) GetRawLuaSchema(ctx context.Context, name string) ([]byte, error) {
+	// if plugin schema is bundled and already loaded into memory
 	rawLuaSchema, ok := v.rawLuaSchemas[name]
-	if !ok {
-		return []byte{}, plugin.ErrSchemaNotFound
+	if ok {
+		return rawLuaSchema, nil
 	}
-	return rawLuaSchema, nil
-}
 
-// GetRawLuaSchemaForCustomPlugin implements the Validator.GetRawLuaSchemaForCustomPlugin interface.
-func (v *LuaValidator) GetRawLuaSchemaForCustomPlugin(ctx context.Context, name string) ([]byte, error) {
+	// otherwise, retrieve it from the StoreLoader
 	start := time.Now()
 	defer func() {
 		v.logger.With(zap.String("plugin", name),


### PR DESCRIPTION
This removes the interface and implementation for `GetRawLuaSchemaForCustomPlugin`.  `GetRawLuaSchema` has been modified to handle non-bundled in addition to bundled plugins, and all references to `GetRawLuaSchemaForCustomPlugin` have been updated to `GetRawLuaSchema`.