### PR TITLE
chore: remove default 'serve' command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,4 @@ RUN adduser --disabled-password --gecos "" koko
 RUN apk --no-cache add ca-certificates bash
 USER koko
 COPY --from=build /koko/koko /usr/local/bin
-ENTRYPOINT ["koko", "serve"]
+ENTRYPOINT ["koko"]


### PR DESCRIPTION
If 'serve' is added, no other command can be executed (such as migrations).
This patch removes the default command and instead asks the user to explicitly specify the command to execute.