### PR TITLE
fix: ensuring non-public errors are not leaked to callers

### DIFF
--- a/internal/server/util/helpers.go
+++ b/internal/server/util/helpers.go
@@ -173,6 +173,8 @@ func HandleErr(ctx context.Context, logger *zap.Logger, err error) error {
 		return status.Error(codes.NotFound, "")
 	}
 
+	// Do not include types that are aliased to the `error`
+	// interface, as it will leak all errors to clients.
 	switch e := err.(type) {
 	case store.ErrConstraint:
 		s := status.New(codes.InvalidArgument, "data constraint error")

--- a/internal/store/opts.go
+++ b/internal/store/opts.go
@@ -1,8 +1,6 @@
 package store
 
 import (
-	"errors"
-
 	"github.com/kong/koko/internal/model"
 	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 )
@@ -88,9 +86,9 @@ type ListOpts struct {
 func (o *ListOpts) validate() error {
 	// TODO(tjasko): Implement proper support for combining both ListFor() & ListWithFilter().
 	if o.Filter != nil && o.ReferenceType != "" && o.ReferenceID != "" {
-		return ErrUnsupportedListOpts(errors.New(
+		return ErrUnsupportedListOpts{
 			"listing resources scoped to a resource while applying a filter are not yet supported",
-		))
+		}
 	}
 
 	return nil
@@ -99,7 +97,11 @@ func (o *ListOpts) validate() error {
 type ListOptsFunc func(*ListOpts)
 
 // ErrUnsupportedListOpts is used when the provided combination of list options is not supported.
-type ErrUnsupportedListOpts error
+type ErrUnsupportedListOpts struct{ message string }
+
+func (e ErrUnsupportedListOpts) Error() string {
+	return e.message
+}
 
 const (
 	DefaultPage     = 1


### PR DESCRIPTION
Corrects a vulnerability where non-public errors could potentially leak to API clients.