### PR TITLE
refactor: various improvements to the persistence store integration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/kong/koko
 go 1.19
 
 require (
+	github.com/DATA-DOG/go-sqlmock v1.5.0
 	github.com/DataDog/datadog-go/v5 v5.1.1
 	github.com/Masterminds/squirrel v1.5.3
 	github.com/bluele/gcache v0.0.2

--- a/go.sum
+++ b/go.sum
@@ -78,6 +78,8 @@ github.com/BurntSushi/toml v1.1.0 h1:ksErzDEI1khOiGPgpwuI7x2ebx/uXQNw7xJpn9Eq1+I
 github.com/BurntSushi/toml v1.1.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/ClickHouse/clickhouse-go v1.4.3/go.mod h1:EaI/sW7Azgz9UATzd5ZdZHRUhHgv5+JMS9NSr2smCJI=
+github.com/DATA-DOG/go-sqlmock v1.5.0 h1:Shsta01QNfFxHCfpW6YH2STWB0MudeXXEWMr20OEh60=
+github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/DataDog/datadog-go/v5 v5.1.1 h1:JLZ6s2K1pG2h9GkvEvMdEGqMDyVLEAccdX5TltWcLMU=
 github.com/DataDog/datadog-go/v5 v5.1.1/go.mod h1:KhiYb2Badlv9/rofz+OznKoEF5XKTonWyhx5K83AP8E=
 github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=

--- a/internal/cmd/db_migrate_up.go
+++ b/internal/cmd/db_migrate_up.go
@@ -20,7 +20,7 @@ var dbMigrateUpCmd = &cobra.Command{
 		logger := opts.Logger
 		logger.Debug("setup successful")
 
-		dbConfig, err := config.ToDBConfig(opts.Config.Database)
+		dbConfig, err := config.ToDBConfig(opts.Config.Database, logger)
 		if err != nil {
 			logger.Fatal(err.Error())
 		}

--- a/internal/cmd/db_status.go
+++ b/internal/cmd/db_status.go
@@ -20,7 +20,7 @@ var dbStatusCmd = &cobra.Command{
 		logger := opts.Logger
 		logger.Debug("setup successful")
 
-		dbConfig, err := config.ToDBConfig(opts.Config.Database)
+		dbConfig, err := config.ToDBConfig(opts.Config.Database, logger)
 		if err != nil {
 			logger.Fatal(err.Error())
 		}

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -433,7 +433,7 @@ func setupGRPCClients(cc *grpc.ClientConn) grpcClients {
 }
 
 func setupDB(logger *zap.Logger, configDB config.Database) (persistence.Persister, error) {
-	config, err := config.ToDBConfig(configDB)
+	config, err := config.ToDBConfig(configDB, logger)
 	if err != nil {
 		logger.Fatal(err.Error())
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,12 +4,8 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"time"
 
 	"github.com/ilyakaznacheev/cleanenv"
-	"github.com/kong/koko/internal/db"
-	"github.com/kong/koko/internal/persistence/postgres"
-	"github.com/kong/koko/internal/persistence/sqlite"
 )
 
 // Get constructs the Config using the filename, env vars and defaults.
@@ -32,29 +28,4 @@ func Get(filename string) (Config, error) {
 		return Config{}, fmt.Errorf("unable to read config: %w", err)
 	}
 	return c, nil
-}
-
-func ToDBConfig(configDB Database) (db.Config, error) {
-	queryTimeout, err := time.ParseDuration(configDB.QueryTimeout)
-	if err != nil {
-		return db.Config{}, fmt.Errorf("failed to parse query timeout: %v", err)
-	}
-	return db.Config{
-		Dialect: configDB.Dialect,
-		SQLite: sqlite.Opts{
-			InMemory: configDB.SQLite.InMemory,
-			Filename: configDB.SQLite.Filename,
-		},
-		Postgres: postgres.Opts{
-			DBName:           configDB.Postgres.DBName,
-			Hostname:         configDB.Postgres.Hostname,
-			ReadOnlyHostname: configDB.Postgres.ReadReplica.Hostname,
-			Port:             configDB.Postgres.Port,
-			User:             configDB.Postgres.User,
-			Password:         configDB.Postgres.Password,
-			EnableTLS:        configDB.Postgres.TLS.Enable,
-			CABundleFSPath:   configDB.Postgres.TLS.CABundlePath,
-		},
-		QueryTimeout: queryTimeout,
-	}, nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"testing"
 
+	"github.com/kong/koko/internal/db"
 	"github.com/stretchr/testify/require"
 )
 
@@ -16,7 +17,7 @@ var defaultConfig = Config{
 	},
 	Control: ControlServer{},
 	Database: Database{
-		Dialect:      "sqlite3",
+		Dialect:      db.DialectSQLite3,
 		QueryTimeout: "5s",
 	},
 	Metrics: Metrics{
@@ -65,7 +66,7 @@ func TestGet(t *testing.T) {
 					TLSKeyPath:  "bar.key",
 				},
 				Database: Database{
-					Dialect: "postgres",
+					Dialect: db.DialectPostgres,
 					SQLite: SQLite{
 						InMemory: true,
 						Filename: "test.db",
@@ -110,7 +111,7 @@ func TestGet(t *testing.T) {
 					TLSKeyPath:  "bar.key",
 				},
 				Database: Database{
-					Dialect: "postgres",
+					Dialect: db.DialectPostgres,
 					SQLite: SQLite{
 						InMemory: true,
 						Filename: "test.db",
@@ -143,7 +144,7 @@ func TestGet(t *testing.T) {
 				envVars: map[string]string{
 					"KOKO_LOG_LEVEL":                               "error",
 					"KOKO_LOG_FORMAT":                              "FOOBAR",
-					"KOKO_DATABASE_DIALECT":                        "postgres",
+					"KOKO_DATABASE_DIALECT":                        db.DialectPostgres,
 					"KOKO_DATABASE_POSTGRES_READ_REPLICA_HOSTNAME": "foobar",
 					"KOKO_DATABASE_POSTGRES_TLS_ENABLE":            "true",
 				},
@@ -157,7 +158,7 @@ func TestGet(t *testing.T) {
 					Address: ":3000",
 				},
 				Database: Database{
-					Dialect: "postgres",
+					Dialect: db.DialectPostgres,
 					Postgres: Postgres{
 						ReadReplica: PostgresReadReplica{
 							Hostname: "foobar",
@@ -196,7 +197,7 @@ func TestGet(t *testing.T) {
 					TLSKeyPath:  "bar.key",
 				},
 				Database: Database{
-					Dialect: "postgres",
+					Dialect: db.DialectPostgres,
 					SQLite: SQLite{
 						InMemory: true,
 						Filename: "test.db",

--- a/internal/config/db.go
+++ b/internal/config/db.go
@@ -1,0 +1,99 @@
+package config
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/kong/koko/internal/db"
+	"github.com/kong/koko/internal/persistence/postgres"
+	"github.com/kong/koko/internal/persistence/sqlite"
+	"go.uber.org/zap"
+)
+
+// Database allows for configuration of Koko's datastore.
+type Database struct {
+	// See db.Dialects for all supported Dialects. This defines which
+	// DB configuration is used, even if multiple DBs are provided.
+	Dialect string `yaml:"dialect" json:"dialect" env:"DIALECT" env-default:"sqlite3"`
+
+	QueryTimeout string `yaml:"query_timeout" json:"query_timeout" env:"QUERY_TIMEOUT" env-default:"5s"`
+
+	SQLite   SQLite   `yaml:"sqlite" json:"sqlite" env-prefix:"SQLITE_"`
+	Postgres Postgres `yaml:"postgres" json:"postgres" env-prefix:"POSTGRES_"`
+}
+
+// Postgres defines configuration for using Postgres as the persistent store.
+type Postgres struct {
+	DBName      string              `yaml:"db_name" json:"db_name" env:"DB_NAME"`
+	Hostname    string              `yaml:"hostname" json:"hostname" env:"HOSTNAME"`
+	Port        int                 `yaml:"port" json:"port" env:"PORT"`
+	ReadReplica PostgresReadReplica `yaml:"read_replica" json:"read_replica" env-prefix:"READ_REPLICA_"`
+	TLS         PostgresTLS         `yaml:"tls" json:"tls" env-prefix:"TLS_"`
+	User        string              `yaml:"user" json:"user" env:"USER"`
+	Password    string              `yaml:"password" json:"password" env:"PASSWORD"`
+}
+
+// PostgresTLS defines configuration for using TLS with Postgres.
+type PostgresTLS struct {
+	CABundlePath string `yaml:"ca_bundle_path" json:"ca_bundle_path" env:"CA_BUNDLE_PATH"`
+	Enable       bool   `yaml:"enable" json:"enable" env:"ENABLE"`
+}
+
+// PostgresReadReplica allows for using a read replica in addition to the
+// primary which shares the same connection settings as the primary DB.
+type PostgresReadReplica struct {
+	Hostname string `yaml:"hostname" json:"hostname" env:"HOSTNAME"`
+}
+
+// SQLite defines configuration for using SQLite as the persistent store.
+type SQLite struct {
+	Filename string `yaml:"filename" json:"filename" env:"FILENAME"`
+	InMemory bool   `yaml:"in_memory" json:"in_memory" env:"IN_MEMORY"`
+}
+
+// Opts returns the options required to instantiate a Postgres persistence.Persister.
+func (c *Postgres) Opts() postgres.Opts {
+	if c.Port == 0 {
+		c.Port = postgres.DefaultPort
+	}
+
+	return postgres.Opts{
+		CABundleFSPath:   c.TLS.CABundlePath,
+		DBName:           c.DBName,
+		EnableTLS:        c.TLS.Enable,
+		Port:             c.Port,
+		Hostname:         c.Hostname,
+		ReadOnlyHostname: c.ReadReplica.Hostname,
+		User:             c.User,
+		Password:         c.Password,
+	}
+}
+
+// Opts returns the options required to instantiate a SQLite persistence.Persister.
+func (c *SQLite) Opts() sqlite.Opts {
+	return sqlite.Opts{
+		InMemory: c.InMemory,
+		Filename: c.Filename,
+	}
+}
+
+// ToDBConfig maps the provided DB application config to the internal representation of the DB config.
+// The resulting config will have its DB config set based on the passed in Database.Dialect.
+func ToDBConfig(config Database, logger *zap.Logger) (db.Config, error) {
+	if logger == nil {
+		logger = zap.L()
+	}
+
+	queryTimeout, err := time.ParseDuration(config.QueryTimeout)
+	if err != nil {
+		return db.Config{}, fmt.Errorf("failed to parse DB query timeout: %w", err)
+	}
+
+	return db.Config{
+		Dialect:      config.Dialect,
+		QueryTimeout: queryTimeout,
+		Logger:       logger,
+		Postgres:     config.Postgres.Opts(),
+		SQLite:       config.SQLite.Opts(),
+	}, nil
+}

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -14,37 +14,6 @@ type ControlServer struct {
 	TLSKeyPath  string `yaml:"tls_key_path" json:"tls_key_path" env:"TLS_KEY_PATH"`
 }
 
-type SQLite struct {
-	InMemory bool   `yaml:"in_memory" json:"in_memory" env:"IN_MEMORY"`
-	Filename string `yaml:"filename" json:"filename" env:"FILENAME"`
-}
-
-type Postgres struct {
-	DBName      string              `yaml:"db_name" json:"db_name" env:"DB_NAME"`
-	Hostname    string              `yaml:"hostname" json:"hostname" env:"HOSTNAME"`
-	ReadReplica PostgresReadReplica `yaml:"read_replica" json:"read_replica" env-prefix:"READ_REPLICA_"`
-	Port        int                 `yaml:"port" json:"port" env:"PORT"`
-	User        string              `yaml:"user" json:"user" env:"USER"`
-	Password    string              `yaml:"password" json:"password" env:"PASSWORD"`
-	TLS         PostgresTLS         `yaml:"tls" json:"tls" env-prefix:"TLS_"`
-}
-
-type PostgresTLS struct {
-	Enable       bool   `yaml:"enable" json:"enable" env:"ENABLE"`
-	CABundlePath string `yaml:"ca_bundle_path" json:"ca_bundle_path" env:"CA_BUNDLE_PATH"`
-}
-
-type PostgresReadReplica struct {
-	Hostname string `yaml:"hostname" json:"hostname" env:"HOSTNAME"`
-}
-
-type Database struct {
-	Dialect      string   `yaml:"dialect" json:"dialect" env:"DIALECT" env-default:"sqlite3"`
-	SQLite       SQLite   `yaml:"sqlite" json:"sqlite" env-prefix:"SQLITE_"`
-	Postgres     Postgres `yaml:"postgres" json:"postgres" env-prefix:"POSTGRES_"`
-	QueryTimeout string   `yaml:"query_timeout" json:"query_timeout" env:"QUERY_TIMEOUT" env-default:"5s"`
-}
-
 // Metrics config.
 type Metrics struct {
 	// ClientType metrics client type e.g. prometheus, datadog.

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -1,0 +1,40 @@
+package db
+
+import (
+	"database/sql"
+	"fmt"
+
+	"github.com/kong/koko/internal/persistence/postgres"
+	"github.com/kong/koko/internal/persistence/sqlite"
+)
+
+// All various supported DB dialects to be used in Koko's database config.
+const (
+	DialectPostgres = "postgres"
+	DialectSQLite3  = "sqlite3"
+)
+
+// Dialects defines all supported DB dialects.
+//
+// This is internally used in unit tests to ensure support for all dialects have been implemented.
+var Dialects = []string{
+	DialectPostgres,
+	DialectSQLite3,
+}
+
+// NewSQLDBFromConfig returns the relevant *sql.DB instance based on the given dialect set on the config.
+func NewSQLDBFromConfig(config Config) (*sql.DB, error) {
+	var db *sql.DB
+	var err error
+
+	switch config.Dialect {
+	case DialectPostgres:
+		db, err = postgres.NewSQLClient(config.Postgres, config.Logger)
+	case DialectSQLite3:
+		db, err = sqlite.NewSQLClient(config.SQLite, config.Logger)
+	default:
+		err = fmt.Errorf("unsupported database '%v'", config.Dialect)
+	}
+
+	return db, err
+}

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1,0 +1,45 @@
+package db
+
+import (
+	"database/sql"
+	"strings"
+	"testing"
+
+	"github.com/kong/koko/internal/persistence/postgres"
+	"github.com/kong/koko/internal/persistence/sqlite"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+func TestNewSQLDBFromConfig(t *testing.T) {
+	config := Config{Logger: zap.L()}
+
+	noOpOpenFunc := func(dataSourceName string) (*sql.DB, error) {
+		return &sql.DB{}, nil
+	}
+
+	t.Run("SQLite", func(t *testing.T) {
+		config.Dialect = DialectSQLite3
+		config.SQLite = sqlite.Opts{SQLOpen: noOpOpenFunc, InMemory: true}
+		_, err := NewSQLDBFromConfig(config)
+		assert.NoError(t, err)
+	})
+
+	t.Run("Postgres", func(t *testing.T) {
+		config.Dialect = DialectPostgres
+		config.Postgres = postgres.Opts{SQLOpen: noOpOpenFunc}
+		_, err := NewSQLDBFromConfig(config)
+		assert.NoError(t, err)
+	})
+
+	t.Run("Check for unimplemented dialects", func(t *testing.T) {
+		for _, dialect := range Dialects {
+			config.Dialect = dialect
+			if _, err := NewSQLDBFromConfig(config); err != nil {
+				if strings.HasPrefix(err.Error(), "unsupported database") {
+					assert.NoError(t, err)
+				}
+			}
+		}
+	})
+}

--- a/internal/db/migrate.go
+++ b/internal/db/migrate.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"database/sql"
 	"errors"
 	"fmt"
 	"os"
@@ -31,11 +32,6 @@ type Config struct {
 	QueryTimeout time.Duration
 }
 
-const (
-	DialectSQLite3  = "sqlite3"
-	DialectPostgres = "postgres"
-)
-
 type Migrator struct {
 	m      *migrate.Migrate
 	logger *zap.Logger
@@ -50,41 +46,34 @@ func sourceForDialect(dialect string) (source.Driver, error) {
 	return source, nil
 }
 
-func driverForDialect(config Config) (database.Driver, error) {
-	switch config.Dialect {
+func driverForDialect(dialect string, db *sql.DB) (database.Driver, error) {
+	var dbDriver database.Driver
+	var err error
+
+	switch dialect {
 	case DialectSQLite3:
-		db, err := sqlite.NewSQLClient(config.SQLite, config.Logger)
-		if err != nil {
-			return nil, err
-		}
-		dbDriver, err := sqlite3.WithInstance(db, &sqlite3.Config{
-			MigrationsTable: "schema_migrations",
+		dbDriver, err = sqlite3.WithInstance(db, &sqlite3.Config{
+			MigrationsTable: sqlite3.DefaultMigrationsTable,
 		})
-		if err != nil {
-			return nil, err
-		}
-		return dbDriver, nil
 	case DialectPostgres:
-		db, err := postgres2.NewSQLClient(config.Postgres, config.Logger)
-		if err != nil {
-			return nil, err
-		}
-		dbDriver, err := postgres.WithInstance(db, &postgres.Config{
+		dbDriver, err = postgres.WithInstance(db, &postgres.Config{
 			MigrationsTable: postgres.DefaultMigrationsTable,
 		})
-		if err != nil {
-			return nil, err
-		}
-		return dbDriver, nil
 	default:
-		return nil, fmt.Errorf("unsupported database '%v'", config.Dialect)
+		return nil, fmt.Errorf("unsupported database '%v'", dialect)
 	}
+
+	return dbDriver, err
 }
 
 func NewMigrator(config Config) (*Migrator, error) {
-	dbDriver, err := driverForDialect(config)
+	sqlDB, err := NewSQLDBFromConfig(config)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to resolve SQL DB instance from the given config: %w", err)
+	}
+	dbDriver, err := driverForDialect(config.Dialect, sqlDB)
+	if err != nil {
+		return nil, fmt.Errorf("unable to resolve DB migration driver from the given dialect: %w", err)
 	}
 	source, err := sourceForDialect(config.Dialect)
 	if err != nil {

--- a/internal/db/migrate_test.go
+++ b/internal/db/migrate_test.go
@@ -1,0 +1,25 @@
+package db
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_driverForDialect(t *testing.T) {
+	db, _, err := sqlmock.New()
+	require.NoError(t, err)
+
+	t.Run("Check for unimplemented dialects", func(t *testing.T) {
+		for _, dialect := range Dialects {
+			if _, err := driverForDialect(dialect, db); err != nil {
+				if strings.HasPrefix(err.Error(), "unsupported database") {
+					assert.NoError(t, err)
+				}
+			}
+		}
+	})
+}

--- a/internal/db/persister.go
+++ b/internal/db/persister.go
@@ -16,16 +16,11 @@ func NewPersister(config Config) (persistence.Persister, error) {
 	switch config.Dialect {
 	case DialectSQLite3:
 		persister, err = sqlite.New(config.SQLite, config.QueryTimeout, config.Logger)
-		if err != nil {
-			return nil, err
-		}
 	case DialectPostgres:
 		persister, err = postgres.New(config.Postgres, config.QueryTimeout, config.Logger)
-		if err != nil {
-			return nil, err
-		}
 	default:
-		return nil, fmt.Errorf("unknown database: %v", config.Dialect)
+		err = fmt.Errorf("unsupported database: %v", config.Dialect)
 	}
-	return persister, nil
+
+	return persister, err
 }

--- a/internal/db/persister_test.go
+++ b/internal/db/persister_test.go
@@ -1,0 +1,23 @@
+package db
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+func TestNewPersister(t *testing.T) {
+	t.Run("Check for unimplemented dialects", func(t *testing.T) {
+		config := Config{Logger: zap.L()}
+		for _, dialect := range Dialects {
+			config.Dialect = dialect
+			if _, err := NewPersister(config); err != nil {
+				if strings.HasPrefix(err.Error(), "unsupported database") {
+					assert.NoError(t, err)
+				}
+			}
+		}
+	})
+}

--- a/internal/persistence/driver.go
+++ b/internal/persistence/driver.go
@@ -1,12 +1,47 @@
 package persistence
 
+import (
+	"database/sql"
+	"time"
+)
+
+// Various default settings used for non-SQLite DB drivers.
+const (
+	DefaultDialTimeout     = 15 * time.Second
+	DefaultMaxConn         = 50
+	DefaultMaxConnLifetime = time.Hour
+	DefaultMaxIdleConn     = 20
+)
+
+// SQLOpenFunc defines a function that can instantiate a sql.DB instance from the given DSN.
+type SQLOpenFunc func(dataSourceName string) (*sql.DB, error)
+
+// Driver represents a specific SQL driver.
 type Driver int
 
+// Supported DB drivers.
 const (
 	SQLite3 Driver = iota
 	Postgres
 )
 
+// DefaultSQLOpenFunc generates a default SQLOpenFunc function for the given SQL persister.
+var DefaultSQLOpenFunc = func(p SQLPersister) SQLOpenFunc {
+	return func(dsn string) (*sql.DB, error) {
+		db, err := sql.Open(p.Driver().String(), dsn)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := p.SetDefaultSQLOptions(db); err != nil {
+			return nil, err
+		}
+
+		return db, nil
+	}
+}
+
+// String returns the applicable registered DB driver name (set via sql.Register).
 func (d Driver) String() string {
-	return [...]string{"sqlite3", "postgres"}[d]
+	return [...]string{"sqlite3", "pgx"}[d]
 }

--- a/internal/persistence/error.go
+++ b/internal/persistence/error.go
@@ -1,0 +1,18 @@
+package persistence
+
+import (
+	"fmt"
+)
+
+// ErrInvalidRowsAffected is used when the number of affected rows does not match the
+// expected amount. This error should usually not be seen under normal circumstances.
+var ErrInvalidRowsAffected = fmt.Errorf("invalid rows affected")
+
+// ErrNotFound is used to indicate the key being looked up was not found in the datastore.
+type ErrNotFound struct {
+	Key string
+}
+
+func (e ErrNotFound) Error() string {
+	return fmt.Sprintf("%v not found", e.Key)
+}

--- a/internal/persistence/postgres/postgres_test.go
+++ b/internal/persistence/postgres/postgres_test.go
@@ -12,7 +12,7 @@ func TestDSN(t *testing.T) {
 		opt := Opts{
 			DBName:    "koko",
 			Hostname:  "localhost",
-			Port:      5432,
+			Port:      DefaultPort,
 			User:      "koko",
 			Password:  "koko",
 			EnableTLS: false,
@@ -27,7 +27,7 @@ func TestDSN(t *testing.T) {
 		opt := Opts{
 			DBName:         "koko",
 			Hostname:       "localhost",
-			Port:           5432,
+			Port:           DefaultPort,
 			User:           "koko",
 			Password:       "koko",
 			EnableTLS:      true,
@@ -44,7 +44,7 @@ func TestDSN(t *testing.T) {
 		opt := Opts{
 			DBName:    "koko",
 			Hostname:  "localhost",
-			Port:      5432,
+			Port:      DefaultPort,
 			User:      "koko",
 			Password:  "koko",
 			EnableTLS: true,

--- a/internal/persistence/sql.go
+++ b/internal/persistence/sql.go
@@ -1,0 +1,15 @@
+package persistence
+
+import (
+	"database/sql"
+)
+
+// SQLPersister should be implemented for all persistence stores that implement an underlining sql.DB driver.
+type SQLPersister interface {
+	// Driver returns the relevant Golang SQL driver used to connect to the database.
+	Driver() Driver
+
+	// SetDefaultSQLOptions is used to set default connection options.
+	// Such options can be overridden by DefaultSQLOpenFunc.
+	SetDefaultSQLOptions(*sql.DB) error
+}

--- a/internal/persistence/store.go
+++ b/internal/persistence/store.go
@@ -2,7 +2,6 @@ package persistence
 
 import (
 	"context"
-	"fmt"
 
 	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 )
@@ -76,12 +75,4 @@ type Tx interface {
 	Commit() error
 	Rollback() error
 	CRUD
-}
-
-type ErrNotFound struct {
-	Key string
-}
-
-func (e ErrNotFound) Error() string {
-	return fmt.Sprintf("%v not found", e.Key)
 }

--- a/internal/test/util/db.go
+++ b/internal/test/util/db.go
@@ -1,0 +1,75 @@
+package util
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/ilyakaznacheev/cleanenv"
+	"github.com/kong/koko/internal/config"
+	"github.com/kong/koko/internal/db"
+	"github.com/kong/koko/internal/persistence/postgres"
+)
+
+// GetAppDatabaseConfig returns the application database configuration, which
+// is usually provided by means of a config file and/or environment variables.
+//
+// This will set defaulted values when no other DB config is set.
+func GetAppDatabaseConfig() (config.Database, error) {
+	var appConfig config.Config
+	if err := cleanenv.ReadEnv(&appConfig); err != nil {
+		return config.Database{}, fmt.Errorf("unable to read config from environment: %w", err)
+	}
+
+	if err := setDBConfig(&appConfig.Database); err != nil {
+		return config.Database{}, fmt.Errorf("unable to set DB config: %w", err)
+	}
+
+	return appConfig.Database, nil
+}
+
+// GetDatabaseConfig is like GetAppDatabaseConfig(), but it converts the
+// app database config to an internal representation of the config.
+func GetDatabaseConfig() (db.Config, error) {
+	appDBConfig, err := GetAppDatabaseConfig()
+	if err != nil {
+		return db.Config{}, err
+	}
+
+	return config.ToDBConfig(appDBConfig, nil)
+}
+
+// setDBConfig determines what DB settings to used based on the environment.
+//
+// We'll assume that when a hostname is provided via the environment, to not use any defaulted config.
+func setDBConfig(conf *config.Database) error {
+	if conf.QueryTimeout == "" {
+		conf.QueryTimeout = queryTimeout.String()
+	}
+
+	// TODO(tjasko): The legacy `KOKO_TEST_DB` environment variable takes precedence over `KOKO_DATABASE_DIALECT`.
+	//  However, we do need to update the codebase to use the newer environment variable.
+	if testDB := os.Getenv("KOKO_TEST_DB"); testDB != "" {
+		conf.Dialect = testDB
+	} else if conf.Dialect == "" {
+		conf.Dialect = db.DialectSQLite3
+	}
+
+	switch conf.Dialect {
+	case db.DialectSQLite3:
+		conf.SQLite = config.SQLite{InMemory: true}
+	case db.DialectPostgres:
+		if conf.Postgres.Hostname == "" {
+			conf.Postgres = config.Postgres{
+				DBName:   "koko",
+				Hostname: "localhost",
+				Port:     postgres.DefaultPort,
+				User:     "koko",
+				Password: "koko",
+			}
+		}
+	default:
+		return fmt.Errorf("unknown DB dialect: %s", conf.Dialect)
+	}
+
+	return nil
+}

--- a/internal/test/util/store.go
+++ b/internal/test/util/store.go
@@ -2,11 +2,13 @@ package util
 
 import (
 	"context"
-	"os"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/golang-migrate/migrate/v4"
+	"github.com/ilyakaznacheev/cleanenv"
+	"github.com/kong/koko/internal/config"
 	"github.com/kong/koko/internal/db"
 	"github.com/kong/koko/internal/log"
 	"github.com/kong/koko/internal/persistence"
@@ -39,33 +41,35 @@ func CleanDB(t *testing.T) error {
 }
 
 func GetPersister(t *testing.T) (persistence.Persister, error) {
-	dbConfig := testConfig
-	dialect := os.Getenv("KOKO_TEST_DB")
-	if dialect == "" {
-		dialect = "sqlite3"
+	var appConfig config.Config
+	if err := cleanenv.ReadEnv(&appConfig); err != nil {
+		return nil, fmt.Errorf("unable to read config from environment: %w", err)
 	}
+
+	if err := setDBConfig(&appConfig.Database); err != nil {
+		return nil, fmt.Errorf("unable to set DB config: %w", err)
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	switch dialect {
-	case "sqlite3":
-		dbClient, err := sqlite.NewSQLClient(dbConfig.SQLite, dbConfig.Logger)
-		if err != nil {
-			t.Fatal(err)
-		}
-		// store may not exist always so ignore the error
-		// TODO(hbagdi): add "IF exists" clause
-		_, _ = dbClient.ExecContext(ctx, "delete from store;")
 
-		dbConfig.Dialect = db.DialectSQLite3
-	case "postgres":
-		dbClient, err := postgres.NewSQLClient(dbConfig.Postgres, dbConfig.Logger)
-		if err != nil {
-			t.Fatal(err)
-		}
-		// store may not exist always so ignore the error
-		// TODO(hbagdi): add "IF exists" clause
+	dbConfig, err := GetDatabaseConfig()
+	if err != nil {
+		return nil, fmt.Errorf("unable to gather test DB config: %w", err)
+	}
+
+	dbClient, err := db.NewSQLDBFromConfig(dbConfig)
+	if err != nil {
+		return nil, fmt.Errorf("unable to resolve SQL DB instance from the given config: %w", err)
+	}
+
+	// store may not exist always so ignore the error
+	// TODO(hbagdi): add "IF exists" clause
+	switch dbConfig.Dialect {
+	case db.DialectSQLite3:
+		_, _ = dbClient.ExecContext(ctx, "delete from store;")
+	case db.DialectPostgres:
 		_, _ = dbClient.ExecContext(ctx, "truncate table store;")
-		dbConfig.Dialect = db.DialectPostgres
 	}
 
 	if err := runMigrations(dbConfig); err != nil {


### PR DESCRIPTION
This is a refactor of the persistence store/DB integration, to reduce some spaghetti code, and to assist when creating new persistence store integrations, like with the recent MySQL integration work going on.

This change also allows for using the `KOKO_DATABASE_*` environment variables during E2E tests, to allow for more configurability when running locally. The legacy `KOKO_TEST_DB` environment variable is still supported, but I imagine we'll want to deprecate it. To reduce scope of these changes, I did not want to do that in this PR.