### PR TITLE
Revert "set multiplatform dev build"

### DIFF
--- a/.github/workflows/dev-builds.yaml
+++ b/.github/workflows/dev-builds.yaml
@@ -24,7 +24,6 @@ jobs:
         with:
           context: .
           file: Dockerfile
-          platforms: linux/amd64,linux/arm64
           push: true
           tags: kong/koko:dev-latest,kong/koko:dev-${{ steps.tag.outputs.tag }}
 


### PR DESCRIPTION
Reverts Kong/koko#447

turns out it's unsupported until changed driver