### PR TITLE
feat: MySQL DB support

### DIFF
--- a/docs/koko-vs-kong.md
+++ b/docs/koko-vs-kong.md
@@ -25,7 +25,8 @@ The following key is used within the document:
 | **Storage**                           |                    |                    |
 | Postgres                              | :heavy_check_mark: | :heavy_check_mark: |
 | SQLite                                | :x:                | :heavy_check_mark: |
-| MySQL                                 | :x:                | :calendar:         |
+| MySQL                                 | :x:                | :heavy_check_mark: |
+| MariaDB                               | :x:                | :calendar:         |
 | SQL Server                            | :x:                | :calendar:         |
 | CockroachDB                           | :x:                | :calendar:         |
 | **Plugins**                           |                    |                    |

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.1.3
 	github.com/cespare/xxhash/v2 v2.1.2
 	github.com/gavv/httpexpect/v2 v2.3.1
+	github.com/go-sql-driver/mysql v1.6.0
 	github.com/golang-migrate/migrate/v4 v4.15.2
 	github.com/golang/protobuf v1.5.2
 	github.com/google/cel-go v0.12.5

--- a/go.sum
+++ b/go.sum
@@ -502,6 +502,8 @@ github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh
 github.com/go-openapi/swag v0.19.14/go.mod h1:QYRuS/SOXUCsnplDa677K7+DxSOj6IPNl/eQntq43wQ=
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
+github.com/go-sql-driver/mysql v1.6.0 h1:BCTh4TKNUYmOmMUcQ3IipzF5prigylS7XXjEkfCHuOE=
+github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/gobuffalo/attrs v0.0.0-20190224210810-a9411de4debd/go.mod h1:4duuawTqi2wkkpB4ePgWMaai6/Kc6WEz83bhFwpHzj0=

--- a/internal/config/db.go
+++ b/internal/config/db.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/kong/koko/internal/db"
+	"github.com/kong/koko/internal/persistence/mysql"
 	"github.com/kong/koko/internal/persistence/postgres"
 	"github.com/kong/koko/internal/persistence/sqlite"
 	"go.uber.org/zap"
@@ -18,8 +19,29 @@ type Database struct {
 
 	QueryTimeout string `yaml:"query_timeout" json:"query_timeout" env:"QUERY_TIMEOUT" env-default:"5s"`
 
+	MySQL    MySQL    `yaml:"mysql" json:"mysql" env-prefix:"MYSQL_"`
 	SQLite   SQLite   `yaml:"sqlite" json:"sqlite" env-prefix:"SQLITE_"`
 	Postgres Postgres `yaml:"postgres" json:"postgres" env-prefix:"POSTGRES_"`
+}
+
+// MySQL defines configuration for using MySQL as the persistent store.
+type MySQL struct {
+	DBName      string           `yaml:"db_name" json:"db_name" env:"DB_NAME"`
+	Hostname    string           `yaml:"hostname" json:"hostname" env:"HOSTNAME"`
+	ReadReplica MySQLReadReplica `yaml:"read_replica" json:"read_replica" env-prefix:"READ_REPLICA_"`
+	Port        int              `yaml:"port" json:"port" env:"PORT"`
+	User        string           `yaml:"user" json:"user" env:"USER"`
+	Password    string           `yaml:"password" json:"password" env:"PASSWORD"`
+	TLS         TLS              `yaml:"tls" json:"tls" env-prefix:"TLS_"`
+
+	// See the `Params` field on mysql.Opts for more info.
+	Params map[string]string `yaml:"params" json:"params" env:"PARAMS"`
+}
+
+// MySQLReadReplica defines configuration for specifying a single read-replica.
+// This configuration overrides fields set in config.MySQL.
+type MySQLReadReplica struct {
+	Hostname string `yaml:"hostname" json:"hostname" env:"HOSTNAME"`
 }
 
 // Postgres defines configuration for using Postgres as the persistent store.
@@ -49,6 +71,32 @@ type PostgresReadReplica struct {
 type SQLite struct {
 	Filename string `yaml:"filename" json:"filename" env:"FILENAME"`
 	InMemory bool   `yaml:"in_memory" json:"in_memory" env:"IN_MEMORY"`
+}
+
+// Opts returns the options required to instantiate a MySQL persistence.Persister.
+func (c *MySQL) Opts() (mysql.Opts, error) {
+	if err := c.TLS.fetchFileContents(); err != nil {
+		return mysql.Opts{}, err
+	}
+
+	opts := mysql.Opts{
+		DBName:           c.DBName,
+		Hostname:         c.Hostname,
+		ReadOnlyHostname: c.ReadReplica.Hostname,
+		Params:           c.Params,
+		Port:             c.Port,
+		User:             c.User,
+		Password:         c.Password,
+
+		// TLS options.
+		EnableTLS:                c.TLS.Enable,
+		RootCA:                   c.TLS.RootCA,
+		Certificate:              c.TLS.Certificate,
+		Key:                      c.TLS.Key,
+		SkipHostnameVerification: c.TLS.SkipHostnameVerification,
+	}
+
+	return opts, nil
 }
 
 // Opts returns the options required to instantiate a Postgres persistence.Persister.
@@ -89,10 +137,16 @@ func ToDBConfig(config Database, logger *zap.Logger) (db.Config, error) {
 		return db.Config{}, fmt.Errorf("failed to parse DB query timeout: %w", err)
 	}
 
+	mysqlOpts, err := config.MySQL.Opts()
+	if err != nil {
+		return db.Config{}, fmt.Errorf("unable to set MySQL DB options: %w", err)
+	}
+
 	return db.Config{
 		Dialect:      config.Dialect,
 		QueryTimeout: queryTimeout,
 		Logger:       logger,
+		MySQL:        mysqlOpts,
 		Postgres:     config.Postgres.Opts(),
 		SQLite:       config.SQLite.Opts(),
 	}, nil

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -1,5 +1,10 @@
 package config
 
+import (
+	"fmt"
+	"os"
+)
+
 type Log struct {
 	Level  string `yaml:"level" json:"level" env:"LEVEL" env-default:"info"`
 	Format string `yaml:"format" json:"format" env:"FORMAT" env-default:"json"`
@@ -20,6 +25,24 @@ type Metrics struct {
 	ClientType string `yaml:"client_type" json:"client_type" env:"CLIENT_TYPE" env-default:"noop"`
 }
 
+// TLS defines re-usable TLS configuration used in tls.Config.
+//
+// If `TLS.Enable` is true and all other fields are empty, peer certificate
+// validation will be skipped and only hostname verification will be done.
+//
+// All `*File` fields will be resolved automatically and thrown into its
+// relevant string field upon config initialization.
+type TLS struct {
+	Enable                   bool   `yaml:"enable" json:"enable" env:"ENABLE"`
+	Certificate              string `yaml:"certificate" json:"certificate" env:"CERTIFICATE"`
+	CertificateFile          string `yaml:"certificate_file" json:"certificate_file" env:"CERTIFICATE_FILE"`
+	Key                      string `yaml:"key" json:"key" env:"KEY"`
+	KeyFile                  string `yaml:"key_file" json:"key_file" env:"KEY_FILE"`
+	RootCA                   string `yaml:"root_ca" json:"root_ca" env:"ROOT_CA"`
+	RootCAFile               string `yaml:"root_ca_file" json:"root_ca_file" env:"ROOT_CA_FILE"`
+	SkipHostnameVerification bool   `yaml:"skip_hostname_verification" json:"skip_hostname_verification" env:"SKIP_HOSTNAME_VERIFICATION"` //nolint:lll
+}
+
 // Config represents configuration of Koko.
 // Configuration is populated via a JSON or YAML file containing or via
 // environment variables.
@@ -35,4 +58,37 @@ type Config struct {
 	Database                Database      `yaml:"database" json:"database" env-prefix:"KOKO_DATABASE_"`
 	Metrics                 Metrics       `yaml:"metrics" json:"metrics" env-prefix:"KOKO_METRICS_"`
 	DisableAnonymousReports bool          `yaml:"disable_anonymous_reports" json:"disable_anonymous_reports" env-prefix:"KOKO_DISABLE_ANONYMOUS_REPORTS"` //nolint:lll
+}
+
+// fetchFileContents gathers file contents from the provided fields and sets it on the applicable string field.
+func (t *TLS) fetchFileContents() error {
+	type fieldData struct {
+		name     string
+		filename string
+		ptr      *string
+	}
+
+	for _, d := range []fieldData{
+		{"root CA", t.RootCAFile, &t.RootCA},
+		{"certificate", t.CertificateFile, &t.Certificate},
+		{"key", t.KeyFile, &t.Key},
+	} {
+		// No filename set for the field, so we can ignore.
+		if d.filename == "" {
+			continue
+		}
+
+		if *d.ptr != "" {
+			return fmt.Errorf("cannot set both %s file & raw string", d.name)
+		}
+
+		b, err := os.ReadFile(d.filename)
+		if err != nil {
+			return fmt.Errorf("unable to read %s file contents: %w", d.name, err)
+		}
+
+		*d.ptr = string(b)
+	}
+
+	return nil
 }

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -2,7 +2,6 @@ package db
 
 import (
 	"database/sql"
-	"errors"
 	"fmt"
 
 	"github.com/kong/koko/internal/persistence/mysql"
@@ -36,7 +35,7 @@ func NewSQLDBFromConfig(config Config) (*sql.DB, error) {
 	switch config.Dialect {
 	case DialectMariaDB:
 		// See mysql.MySQL on why MariaDB is not supported.
-		err = errors.New("MariaDB is currently unsupported")
+		err = mysql.ErrMariaDBUnsupported
 	case DialectMySQL:
 		db, err = mysql.NewSQLClient(config.MySQL, config.Logger)
 	case DialectPostgres:

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -2,14 +2,18 @@ package db
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 
+	"github.com/kong/koko/internal/persistence/mysql"
 	"github.com/kong/koko/internal/persistence/postgres"
 	"github.com/kong/koko/internal/persistence/sqlite"
 )
 
 // All various supported DB dialects to be used in Koko's database config.
 const (
+	DialectMariaDB  = "mariadb"
+	DialectMySQL    = "mysql"
 	DialectPostgres = "postgres"
 	DialectSQLite3  = "sqlite3"
 )
@@ -18,6 +22,8 @@ const (
 //
 // This is internally used in unit tests to ensure support for all dialects have been implemented.
 var Dialects = []string{
+	DialectMariaDB,
+	DialectMySQL,
 	DialectPostgres,
 	DialectSQLite3,
 }
@@ -28,6 +34,11 @@ func NewSQLDBFromConfig(config Config) (*sql.DB, error) {
 	var err error
 
 	switch config.Dialect {
+	case DialectMariaDB:
+		// See mysql.MySQL on why MariaDB is not supported.
+		err = errors.New("MariaDB is currently unsupported")
+	case DialectMySQL:
+		db, err = mysql.NewSQLClient(config.MySQL, config.Logger)
 	case DialectPostgres:
 		db, err = postgres.NewSQLClient(config.Postgres, config.Logger)
 	case DialectSQLite3:

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/kong/koko/internal/persistence/mysql"
 	"github.com/kong/koko/internal/persistence/postgres"
 	"github.com/kong/koko/internal/persistence/sqlite"
 	"github.com/stretchr/testify/assert"
@@ -17,6 +18,19 @@ func TestNewSQLDBFromConfig(t *testing.T) {
 	noOpOpenFunc := func(dataSourceName string) (*sql.DB, error) {
 		return &sql.DB{}, nil
 	}
+
+	t.Run("MariaDB", func(t *testing.T) {
+		config.Dialect = DialectMariaDB
+		_, err := NewSQLDBFromConfig(config)
+		assert.EqualError(t, err, "MariaDB is currently unsupported")
+	})
+
+	t.Run("MySQL", func(t *testing.T) {
+		config.Dialect = DialectMySQL
+		config.MySQL = mysql.Opts{SQLOpen: noOpOpenFunc}
+		_, err := NewSQLDBFromConfig(config)
+		assert.NoError(t, err)
+	})
 
 	t.Run("SQLite", func(t *testing.T) {
 		config.Dialect = DialectSQLite3

--- a/internal/db/migrate.go
+++ b/internal/db/migrate.go
@@ -56,7 +56,7 @@ func driverForDialect(dialect string, db *sql.DB) (database.Driver, error) {
 	switch dialect {
 	case DialectMariaDB:
 		// See mysql.MySQL on why MariaDB is not supported.
-		err = errors.New("MariaDB is currently unsupported")
+		err = mysql2.ErrMariaDBUnsupported
 	case DialectMySQL:
 		dbDriver, err = mysql.WithInstance(db, &mysql.Config{
 			MigrationsTable: mysql.DefaultMigrationsTable,

--- a/internal/db/migrate.go
+++ b/internal/db/migrate.go
@@ -9,10 +9,12 @@ import (
 
 	"github.com/golang-migrate/migrate/v4"
 	"github.com/golang-migrate/migrate/v4/database"
+	"github.com/golang-migrate/migrate/v4/database/mysql"
 	"github.com/golang-migrate/migrate/v4/database/postgres"
 	"github.com/golang-migrate/migrate/v4/database/sqlite3"
 	"github.com/golang-migrate/migrate/v4/source"
 	"github.com/golang-migrate/migrate/v4/source/iofs"
+	mysql2 "github.com/kong/koko/internal/persistence/mysql"
 	postgres2 "github.com/kong/koko/internal/persistence/postgres"
 	"github.com/kong/koko/internal/persistence/sqlite"
 	"go.uber.org/zap"
@@ -25,8 +27,9 @@ type SQLite struct {
 
 type Config struct {
 	Dialect  string
-	SQLite   sqlite.Opts
+	MySQL    mysql2.Opts
 	Postgres postgres2.Opts
+	SQLite   sqlite.Opts
 
 	Logger       *zap.Logger
 	QueryTimeout time.Duration
@@ -51,6 +54,13 @@ func driverForDialect(dialect string, db *sql.DB) (database.Driver, error) {
 	var err error
 
 	switch dialect {
+	case DialectMariaDB:
+		// See mysql.MySQL on why MariaDB is not supported.
+		err = errors.New("MariaDB is currently unsupported")
+	case DialectMySQL:
+		dbDriver, err = mysql.WithInstance(db, &mysql.Config{
+			MigrationsTable: mysql.DefaultMigrationsTable,
+		})
 	case DialectSQLite3:
 		dbDriver, err = sqlite3.WithInstance(db, &sqlite3.Config{
 			MigrationsTable: sqlite3.DefaultMigrationsTable,

--- a/internal/db/persister.go
+++ b/internal/db/persister.go
@@ -1,9 +1,11 @@
 package db
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/kong/koko/internal/persistence"
+	"github.com/kong/koko/internal/persistence/mysql"
 	"github.com/kong/koko/internal/persistence/postgres"
 	"github.com/kong/koko/internal/persistence/sqlite"
 )
@@ -14,6 +16,11 @@ func NewPersister(config Config) (persistence.Persister, error) {
 		err       error
 	)
 	switch config.Dialect {
+	case DialectMariaDB:
+		// See mysql.MySQL on why MariaDB is not supported.
+		err = errors.New("MariaDB is currently unsupported")
+	case DialectMySQL:
+		persister, err = mysql.New(config.MySQL, config.QueryTimeout, config.Logger)
 	case DialectSQLite3:
 		persister, err = sqlite.New(config.SQLite, config.QueryTimeout, config.Logger)
 	case DialectPostgres:

--- a/internal/db/persister.go
+++ b/internal/db/persister.go
@@ -1,7 +1,6 @@
 package db
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/kong/koko/internal/persistence"
@@ -18,7 +17,7 @@ func NewPersister(config Config) (persistence.Persister, error) {
 	switch config.Dialect {
 	case DialectMariaDB:
 		// See mysql.MySQL on why MariaDB is not supported.
-		err = errors.New("MariaDB is currently unsupported")
+		err = mysql.ErrMariaDBUnsupported
 	case DialectMySQL:
 		persister, err = mysql.New(config.MySQL, config.QueryTimeout, config.Logger)
 	case DialectSQLite3:

--- a/internal/db/sql/mysql/0001_init.down.sql
+++ b/internal/db/sql/mysql/0001_init.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE store;

--- a/internal/db/sql/mysql/0001_init.up.sql
+++ b/internal/db/sql/mysql/0001_init.up.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS store (
+  `key` VARCHAR(512) NOT NULL,
+  value JSON,
+  PRIMARY KEY (`key`),
+  INDEX tags_idx ((CAST(value -> '$.object.tags' AS CHAR(128) ARRAY)))
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_520_ci;

--- a/internal/persistence/driver.go
+++ b/internal/persistence/driver.go
@@ -23,6 +23,7 @@ type Driver int
 const (
 	SQLite3 Driver = iota
 	Postgres
+	MySQL
 )
 
 // DefaultSQLOpenFunc generates a default SQLOpenFunc function for the given SQL persister.
@@ -43,5 +44,5 @@ var DefaultSQLOpenFunc = func(p SQLPersister) SQLOpenFunc {
 
 // String returns the applicable registered DB driver name (set via sql.Register).
 func (d Driver) String() string {
-	return [...]string{"sqlite3", "pgx"}[d]
+	return [...]string{"sqlite3", "pgx", "mysql"}[d]
 }

--- a/internal/persistence/mysql/mysql.go
+++ b/internal/persistence/mysql/mysql.go
@@ -3,6 +3,7 @@ package mysql
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"time"
 
@@ -13,6 +14,9 @@ import (
 	"go.uber.org/zap"
 	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 )
+
+// ErrMariaDBUnsupported is the error returned when db.DialectMariaDB is attempted to be used.
+var ErrMariaDBUnsupported = errors.New("MariaDB is currently unsupported")
 
 // MySQL defines a persistence store integration for databases that speak the MySQL protocol.
 //

--- a/internal/persistence/mysql/mysql.go
+++ b/internal/persistence/mysql/mysql.go
@@ -1,0 +1,308 @@
+package mysql
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	sq "github.com/Masterminds/squirrel"
+	"github.com/google/cel-go/common/operators"
+	"github.com/kong/koko/internal/json"
+	"github.com/kong/koko/internal/persistence"
+	"go.uber.org/zap"
+	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
+)
+
+// MySQL defines a persistence store integration for databases that speak the MySQL protocol.
+//
+// Officially supported databases include:
+// - MySQL   >= 8.0.17
+// - MariaDB >= 10.9.2
+//
+// MySQL 8.0.17 is the minimum supported version, as it supports multivalued/inverted indexes,
+// which is required to ensure indexes are hit when using `JSON_CONTAINS()` & `JSON_OVERLAPS()`.
+// Read more: https://dev.mysql.com/doc/refman/8.0/en/create-index.html#create-index-multi-valued
+//
+// MariaDB 10.9.2 is the minimum supported version as that is when the `JSON_OVERLAPS()` function
+// was introduced.
+//
+// However, MariaDB is not currently supported, as it will require use of a virtual column to handle row
+// filtering, to support things like tag-based listing, as it currently does not support functional indexes
+// like MySQL does. While this isn't difficult to support, we're punting this support for the future.
+// Read more: https://mariadb.com/resources/blog/json-with-mariadb-10-2
+type MySQL struct {
+	db, readOnlyDB *sql.DB
+	queryTimeout   time.Duration
+}
+
+func (s *MySQL) Driver() persistence.Driver { return persistence.MySQL }
+
+func (s *MySQL) SetDefaultSQLOptions(db *sql.DB) error {
+	db.SetMaxOpenConns(persistence.DefaultMaxConn)
+	db.SetMaxIdleConns(persistence.DefaultMaxIdleConn)
+	db.SetConnMaxLifetime(persistence.DefaultMaxConnLifetime)
+	return nil
+}
+
+func (s *MySQL) Get(ctx context.Context, key string) ([]byte, error) {
+	return (&mysqlQuery{s.readOnlyDB, s.queryTimeout}).Get(ctx, key)
+}
+
+func (s *MySQL) Put(ctx context.Context, key string, value []byte) error {
+	return (&mysqlQuery{s.db, s.queryTimeout}).Put(ctx, key, value)
+}
+
+func (s *MySQL) Delete(ctx context.Context, key string) error {
+	return (&mysqlQuery{s.db, s.queryTimeout}).Delete(ctx, key)
+}
+
+func (s *MySQL) List(
+	ctx context.Context,
+	prefix string,
+	opts *persistence.ListOpts,
+) (persistence.ListResult, error) {
+	return (&mysqlQuery{s.readOnlyDB, s.queryTimeout}).List(ctx, prefix, opts)
+}
+
+func (s *MySQL) Tx(ctx context.Context) (persistence.Tx, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return &mysqlTx{
+		tx: tx,
+		query: mysqlQuery{
+			StdSqlCtx:    tx,
+			queryTimeout: s.queryTimeout,
+		},
+	}, nil
+}
+
+func (s *MySQL) Close() error {
+	return s.db.Close()
+}
+
+func NewSQLClient(opts Opts, logger *zap.Logger) (*sql.DB, error) {
+	if err := opts.Validate(); err != nil {
+		return nil, err
+	}
+
+	opts.logger = logger
+	dsn, err := opts.DSN()
+	if err != nil {
+		return nil, err
+	}
+
+	openFunc := persistence.DefaultSQLOpenFunc(&MySQL{})
+	if opts.SQLOpen != nil {
+		openFunc = opts.SQLOpen
+	}
+
+	return openFunc(dsn)
+}
+
+func New(opts Opts, queryTimeout time.Duration, logger *zap.Logger) (persistence.Persister, error) {
+	db, err := NewSQLClient(opts, logger)
+	if err != nil {
+		return nil, fmt.Errorf("unable to set up MySQL DB client: %w", err)
+	}
+
+	// By default, fallback to primary host for read operations.
+	readOnlyDB := db
+	if opts.ReadOnlyHostname != "" {
+		readOnlyOpts := opts
+		readOnlyOpts.Hostname = opts.ReadOnlyHostname
+		if readOnlyDB, err = NewSQLClient(readOnlyOpts, logger); err != nil {
+			return nil, fmt.Errorf("unable to set up read-only MySQL DB client: %w", err)
+		}
+	}
+
+	return &MySQL{
+		db:           db,
+		readOnlyDB:   readOnlyDB,
+		queryTimeout: queryTimeout,
+	}, nil
+}
+
+type mysqlQuery struct {
+	sq.StdSqlCtx
+	queryTimeout time.Duration
+}
+
+func (t *mysqlQuery) Get(ctx context.Context, key string) ([]byte, error) {
+	rawSQL, placeholders, err := sq.StatementBuilder.
+		Select("*").
+		From("store").
+		Where("`key` = ?", key).
+		ToSql()
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, t.queryTimeout)
+	defer cancel()
+
+	var resKey string
+	var value []byte
+	row := t.QueryRowContext(ctx, rawSQL, placeholders...)
+	if err := row.Scan(&resKey, &value); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, persistence.ErrNotFound{Key: key}
+		}
+		return nil, err
+	}
+
+	return value, nil
+}
+
+func (t *mysqlQuery) Put(ctx context.Context, key string, value []byte) error {
+	rawSQL, placeholders, err := sq.StatementBuilder.
+		Insert("store").
+		Columns("`key`", "value").
+		Values(key, value).
+		Suffix("ON DUPLICATE KEY UPDATE value = ?", value).
+		ToSql()
+	if err != nil {
+		return err
+	}
+
+	// We cannot check the affected rows, as per the MySQL docs:
+	//
+	// "For INSERT ... ON DUPLICATE KEY UPDATE statements, the affected-rows value per row is 1
+	// if the row is inserted as a new row, 2 if an existing row is updated, and 0 if an existing
+	// row is set to its current values. If you specify the CLIENT_FOUND_ROWS flag, the affected-rows
+	// value is 1 (not 0) if an existing row is set to its current values."
+	//
+	// The `CLIENT_FOUND_ROWS` flag cannot be used, as it impacts UPDATE statements by returning
+	// total number of found rows. As such, we are not returning a `persistence.ErrInvalidRowsAffected`
+	// error when inserting rows & no rows have been affected.
+	//
+	// Read more: https://dev.mysql.com/doc/c-api/8.0/en/mysql-affected-rows.html
+	ctx, cancel := context.WithTimeout(ctx, t.queryTimeout)
+	defer cancel()
+	if _, err = t.ExecContext(ctx, rawSQL, placeholders...); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (t *mysqlQuery) Delete(ctx context.Context, key string) error {
+	rawSQL, placeholders, err := sq.StatementBuilder.
+		Delete("store").
+		Where("`key` = ?", key).
+		ToSql()
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, t.queryTimeout)
+	defer cancel()
+	res, err := t.ExecContext(ctx, rawSQL, placeholders...)
+	if err != nil {
+		return err
+	}
+
+	rowCount, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+
+	if rowCount == 0 {
+		return persistence.ErrNotFound{Key: key}
+	}
+	if rowCount != 1 {
+		return persistence.ErrInvalidRowsAffected
+	}
+
+	return nil
+}
+
+func (t *mysqlQuery) List(
+	ctx context.Context,
+	prefix string,
+	opts *persistence.ListOpts,
+) (persistence.ListResult, error) {
+	ctx, cancel := context.WithTimeout(ctx, t.queryTimeout)
+	defer cancel()
+
+	query := sq.StatementBuilder.
+		Select("`key`", "value", "COUNT(*) OVER() AS full_count").
+		From("store").
+		Where("`key` LIKE ?", prefix+"%").
+		OrderBy("`key`").
+		Limit(uint64(opts.Limit)).
+		Offset(uint64(opts.Offset))
+
+	// Parse out any provided, pre-validated CEL expression & add the proper clauses to the query.
+	var err error
+	if query, err = addFilterToQuery(query, opts.Filter); err != nil {
+		return persistence.ListResult{}, fmt.Errorf("unable to add filter CEL expression to query: %w", err)
+	}
+
+	rawSQL, placeholders, err := query.ToSql()
+	if err != nil {
+		return persistence.ListResult{}, err
+	}
+	rows, err := t.QueryContext(ctx, rawSQL, placeholders...)
+	if err != nil {
+		return persistence.ListResult{}, err
+	}
+	defer rows.Close()
+	if rows.Err() != nil {
+		return persistence.ListResult{}, rows.Err()
+	}
+
+	res := persistence.ListResult{KVList: make([]persistence.KVResult, 0, opts.Limit)}
+	for rows.Next() {
+		var kvr persistence.KVResult
+		if err := rows.Scan(&kvr.Key, &kvr.Value, &res.TotalCount); err != nil {
+			return persistence.ListResult{}, err
+		}
+		res.KVList = append(res.KVList, kvr)
+	}
+
+	return res, nil
+}
+
+func addFilterToQuery(query sq.SelectBuilder, expr *exprpb.Expr) (sq.SelectBuilder, error) {
+	// No-op when no expression is provided.
+	if expr == nil {
+		return query, nil
+	}
+
+	tags, exprFunction, err := persistence.GetTagsFromExpression(expr)
+	if err != nil {
+		return query, err
+	}
+
+	queryArgs, err := persistence.GetQueryArgsFromExprConstants(tags)
+	if err != nil {
+		return query, err
+	}
+
+	// No-op when there are no tags to filter against, to treat it as if there is no filter at all.
+	if len(queryArgs) == 0 {
+		return query, nil
+	}
+
+	tagsJSON, err := json.Marshal(queryArgs)
+	if err != nil {
+		return query, err
+	}
+
+	// As the only supported field name to filter on are tags, we can simply hard-code the predicate.
+	//
+	// NOTE: The `->` & `->>` operators shall never be used, as they are not supported in MariaDB.
+	// Instead, `JSON_EXTRACT()` should be used in its place.
+	const tagsSelector = "JSON_EXTRACT(value, '$.object.tags')"
+	if exprFunction == operators.LogicalOr {
+		query = query.Where("JSON_OVERLAPS("+tagsSelector+", ?)", tagsJSON)
+	} else {
+		query = query.Where("JSON_CONTAINS("+tagsSelector+", ?, '$')", tagsJSON)
+	}
+
+	return query, nil
+}

--- a/internal/persistence/mysql/options.go
+++ b/internal/persistence/mysql/options.go
@@ -1,0 +1,192 @@
+package mysql
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/go-sql-driver/mysql"
+	"github.com/kong/koko/internal/persistence"
+	"go.uber.org/zap"
+)
+
+var defaultCollation = "utf8mb4_unicode_520_ci"
+
+var (
+	unsupportedParamErrPrefix = "the '%s' parameter is unsupported, "
+	unsupportedParamErrs      = map[string]string{
+		"clientFoundRows":  unsupportedParamErrPrefix + " as it will break functionality",
+		"collation":        unsupportedParamErrPrefix + " as it is defaulted to " + defaultCollation,
+		"columnsWithAlias": unsupportedParamErrPrefix + " as it can break functionality",
+		"multiStatements":  unsupportedParamErrPrefix + " to prevent against SQL injection attacks",
+		"parseTime":        unsupportedParamErrPrefix + " as it is forced on by default",
+		"tls":              unsupportedParamErrPrefix + " please instead use 'tls.enable' & its accompanying fields",
+	}
+)
+
+// Opts defines various options when creating a MySQL DB instance.
+type Opts struct {
+	// Primary (read/write) DB connection settings.
+	DBName   string
+	Hostname string
+	Port     int
+	User     string
+	Password string
+
+	// Optional hostname for a read-only replica.
+	// Connection to this DB shares the same options as the primary (Opts.Hostname).
+	ReadOnlyHostname string
+
+	// TLS options.
+	EnableTLS                bool
+	RootCA                   string
+	Certificate              string
+	Key                      string
+	SkipHostnameVerification bool
+
+	// Defaults to UTC when not provided.
+	Location *time.Location
+
+	// Optional function for defining the connection to the DB.
+	// When not provided, defaults to persistence.DefaultSQLOpenFunc.
+	SQLOpen persistence.SQLOpenFunc
+
+	// Parameters passed to the MySQL DB driver.
+	//
+	// This is here to allow the enablement of useful parameters, like `checkConnLiveness=true`.
+	//
+	// Read more: https://github.com/go-sql-driver/mysql#parameters
+	Params map[string]string
+
+	logger *zap.Logger
+}
+
+// Validate ensures the provided MySQL options are a valid configuration.
+func (o *Opts) Validate() error {
+	// Ensure no parameters are set that could hinder functionality or cause potential issues.
+	for key := range o.Params {
+		if msg, ok := unsupportedParamErrs[key]; ok {
+			return fmt.Errorf(msg, key)
+		}
+	}
+
+	return nil
+}
+
+// DSN formats the given Opts into a DSN string which can be passed to the driver.
+func (o *Opts) DSN() (string, error) {
+	if o.Params == nil {
+		o.Params = make(map[string]string)
+	}
+
+	if o.Location == nil {
+		o.Location = time.UTC
+	}
+
+	if o.Port != 0 {
+		o.Hostname += ":" + strconv.Itoa(o.Port)
+	}
+
+	if o.logger == nil {
+		o.logger = zap.L()
+	}
+
+	config := mysql.Config{
+		// Default settings.
+		AllowNativePasswords: true,
+		Collation:            defaultCollation,
+		Net:                  "tcp",
+		ParseTime:            true,
+		Timeout:              persistence.DefaultDialTimeout,
+
+		// Dynamic settings.
+		Addr:   o.Hostname,
+		DBName: o.DBName,
+		Loc:    o.Location,
+		Params: o.Params,
+		User:   o.User,
+		Passwd: o.Password,
+	}
+
+	if o.EnableTLS {
+		o.logger.Info("using TLS MySQL connection")
+		if err := o.setTLSConfig(&config); err != nil {
+			return "", err
+		}
+	} else {
+		o.logger.Info("using non-TLS MySQL connection")
+	}
+
+	return config.FormatDSN(), nil
+}
+
+func (o *Opts) setTLSConfig(dbConfig *mysql.Config) error {
+	dbConfig.TLSConfig = "custom"
+
+	tlsConfig := &tls.Config{} //nolint:gosec
+
+	if o.RootCA != "" {
+		tlsConfig.RootCAs = x509.NewCertPool()
+		if ok := tlsConfig.RootCAs.AppendCertsFromPEM([]byte(o.RootCA)); !ok {
+			return errors.New("unable to append root cert to pool")
+		}
+	}
+
+	// Whenever hostname verification needs to be skipped or the cert/key was not provided,
+	// we'll need to override the default peer certificate validation logic.
+	if o.SkipHostnameVerification || o.Certificate == "" && o.Key == "" {
+		tlsConfig.InsecureSkipVerify = true
+		tlsConfig.VerifyPeerCertificate = o.verifyPeerCertFunc(tlsConfig.RootCAs)
+	}
+
+	if o.Certificate != "" && o.Key != "" {
+		cert, err := tls.X509KeyPair([]byte(o.Certificate), []byte(o.Key))
+		if err != nil {
+			return err
+		}
+		tlsConfig.Certificates = []tls.Certificate{cert}
+	} else if tlsConfig.RootCAs == nil {
+		// Not providing a root CA or a cert/key is very insecure. As such, we'll let them
+		// proceed, but emit a warning when peer certificate verification is skipped.
+		o.logger.Warn(
+			"⚠️ Using an insecure TLS MySQL connection with no peer certificate validation! " +
+				"Are you sure you meant to use an insecure TLS connection? ⚠️",
+		)
+	}
+
+	return mysql.RegisterTLSConfig(dbConfig.TLSConfig, tlsConfig)
+}
+
+// verifyPeerCertFunc handles X509 certificate validation in the event we're not doing full TLS validation.
+func (o *Opts) verifyPeerCertFunc(pool *x509.CertPool) func([][]byte, [][]*x509.Certificate) error {
+	return func(rawCerts [][]byte, _ [][]*x509.Certificate) error {
+		// This functions as insecure TLS.
+		if pool == nil && o.SkipHostnameVerification {
+			return nil
+		}
+
+		if len(rawCerts) == 0 {
+			return errors.New("no certificates available to verify")
+		}
+
+		cert, err := x509.ParseCertificate(rawCerts[0])
+		if err != nil {
+			return err
+		}
+
+		// When no CA certificate provided, we still need to validate the hostname. Otherwise,
+		// we'll want to verify the peer certificate without checking the hostname.
+		if pool == nil {
+			if err := cert.VerifyHostname(o.Hostname); err != nil {
+				return err
+			}
+		} else if _, err = cert.Verify(x509.VerifyOptions{Roots: pool}); err != nil {
+			return err
+		}
+
+		return nil
+	}
+}

--- a/internal/persistence/mysql/tx.go
+++ b/internal/persistence/mysql/tx.go
@@ -1,0 +1,27 @@
+package mysql
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/kong/koko/internal/persistence"
+)
+
+type mysqlTx struct {
+	tx    *sql.Tx
+	query mysqlQuery
+}
+
+func (t *mysqlTx) Commit() error { return t.tx.Commit() }
+
+func (t *mysqlTx) Rollback() error { return t.tx.Rollback() }
+
+func (t *mysqlTx) Get(ctx context.Context, k string) ([]byte, error) { return t.query.Get(ctx, k) }
+
+func (t *mysqlTx) Put(ctx context.Context, k string, v []byte) error { return t.query.Put(ctx, k, v) }
+
+func (t *mysqlTx) Delete(ctx context.Context, k string) error { return t.query.Delete(ctx, k) }
+
+func (t *mysqlTx) List(ctx context.Context, prefix string, opts *persistence.ListOpts) (persistence.ListResult, error) {
+	return t.query.List(ctx, prefix, opts)
+}

--- a/internal/test/util/db.go
+++ b/internal/test/util/db.go
@@ -55,6 +55,15 @@ func setDBConfig(conf *config.Database) error {
 	}
 
 	switch conf.Dialect {
+	case db.DialectMySQL:
+		if conf.MySQL.Hostname == "" {
+			conf.MySQL = config.MySQL{
+				DBName:   "koko",
+				Hostname: "localhost",
+				User:     "koko",
+				Password: "koko",
+			}
+		}
 	case db.DialectSQLite3:
 		conf.SQLite = config.SQLite{InMemory: true}
 	case db.DialectPostgres:

--- a/internal/test/util/store.go
+++ b/internal/test/util/store.go
@@ -66,6 +66,8 @@ func GetPersister(t *testing.T) (persistence.Persister, error) {
 	// store may not exist always so ignore the error
 	// TODO(hbagdi): add "IF exists" clause
 	switch dbConfig.Dialect {
+	case db.DialectMariaDB, db.DialectMySQL:
+		_, _ = dbClient.ExecContext(ctx, "truncate table store;")
 	case db.DialectSQLite3:
 		_, _ = dbClient.ExecContext(ctx, "delete from store;")
 	case db.DialectPostgres:

--- a/koko.yaml
+++ b/koko.yaml
@@ -2,8 +2,57 @@ log:
   level: debug
   format: console
 database:
+  # Supported database dialects include:
+  # - mysql
+  # - postgres
+  # - sqlite3
   dialect: sqlite3
   query_timeout: 5s
+  mysql:
+    # Required fields to set primary DB settings.
+    hostname: localhost
+    db_name: koko
+    user: koko
+    password: koko
+
+    # Optional, otherwise defaults to 3306.
+    port: 3306
+
+    tls:
+      # In order to enable TLS negotiation, this must be enabled,
+      # otherwise, no TLS negotiation will be done.
+      #
+      # Defaults to false when not provided.
+      enable: true
+
+      # Enable in the event hostname verification needs to be skipped.
+      #
+      # Defaults to false when not provided.
+      skip_hostname_verification: false
+
+      # Optional root CA, certificate, and key settings.
+      #
+      # You may specify the `*_file` fields or provide the data in plain text.
+      #
+      # root_ca_file: /some/path/to/ca.pem
+      # certificate_file: /some/path/to/cert.pem
+      # key_file: /some/path/to/key.pem
+      root_ca: |
+        -----BEGIN CERTIFICATE-----
+        ...
+        -----END CERTIFICATE-----
+      certificate: |
+        -----BEGIN CERTIFICATE-----
+        ...
+        -----END CERTIFICATE-----
+      key: |
+        -----BEGIN RSA PRIVATE KEY-----
+        ...
+        -----END RSA PRIVATE KEY-----
+
+    # Optional hostname to declare a single read-replica. Shares the
+    # same connectivity settings as the primary DB settings above.
+    read_replica: another-hostname
   sqlite:
     #in_memory: true
     filename: test.db

--- a/koko.yaml
+++ b/koko.yaml
@@ -52,7 +52,8 @@ database:
 
     # Optional hostname to declare a single read-replica. Shares the
     # same connectivity settings as the primary DB settings above.
-    read_replica: another-hostname
+    read_replica:
+      hostname: another-hostname
   sqlite:
     #in_memory: true
     filename: test.db


### PR DESCRIPTION
This change introduces support for MySQL >= 8.0.17.

—

**Work remaining/completed:**
- [x] Throw up PR to handle some refactoring of the persistence store integration.
  - See #450.
- [x] Implement MySQL persistence store support.
  - [x] Support tag-based listing (ensuring indexes are hit).
- [x] Run MySQL part of the CI test suite.
  - See #458.
- [x] Test in AWS RDS to ensure compatibility.
  - I tested MySQL with their minimum supported version of 8.0.23 and the latest supported version of 8.0.30. All works as expected.
- [x] Complete & verify TLS connection support.
