### PR TITLE
chore: updating govulncheck to run with the latest Go 1.19 version

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -22,6 +22,7 @@ jobs:
       uses: actions/setup-go@v3
       with:
         go-version: '^1.19'
+        check-latest: true
     - name: Checkout repository
       uses: actions/checkout@v3
     - name: Cache Go modules

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -8,6 +8,7 @@ jobs:
       uses: actions/setup-go@v3
       with:
         go-version: '^1.19'
+        check-latest: true
     - name: Checkout repository
       uses: actions/checkout@v3
     - name: Cache Go modules

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -7,7 +7,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: '^1.19.1'
+        go-version: '^1.19'
     - name: Checkout repository
       uses: actions/checkout@v3
     - name: make install-tools

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -8,6 +8,7 @@ jobs:
       uses: actions/setup-go@v3
       with:
         go-version: '^1.19'
+        check-latest: true
     - name: Checkout repository
       uses: actions/checkout@v3
     - name: make install-tools

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -16,6 +16,7 @@ jobs:
       uses: actions/setup-go@v3
       with:
         go-version: '^1.19'
+        check-latest: true
     - name: Checkout repository
       uses: actions/checkout@v3
     - name: Cache Go modules


### PR DESCRIPTION
This matches our build logic, as we also currently build using the latest Go 1.19 version as well.

This is done to correct the following vulnerability:

```
Vulnerability #1: GO-2022-1039
  Programs which compile regular expressions from untrusted
  sources may be vulnerable to memory exhaustion or denial of
  service. The parsed regexp representation is linear in the size
  of the input, but in some cases the constant factor can be as
  high as 40,000, making relatively small regexps consume much
  larger amounts of memory. After fix, each regexp being parsed is
  limited to a 256 MB memory footprint. Regular expressions whose
  representation would use more space than that are rejected.
  Normal use of regular expressions is unaffected.

  Found in: regexp/syntax@go1.19.1
  Fixed in: regexp/syntax@go1.19.2
  More info: https://pkg.go.dev/vuln/GO-2022-1039
```