### PR TITLE
fix: improve unexpected plugins validation errors handling

### DIFF
--- a/internal/plugin/validators/badtestdata/embed.go
+++ b/internal/plugin/validators/badtestdata/embed.go
@@ -1,0 +1,8 @@
+package badtestdata
+
+import (
+	"embed"
+)
+
+//go:embed lua-tree/share/lua/5.1/*
+var BadLuaTree embed.FS

--- a/internal/plugin/validators/badtestdata/lua-tree/share/lua/5.1/validate-invalid-json.lua
+++ b/internal/plugin/validators/badtestdata/lua-tree/share/lua/5.1/validate-invalid-json.lua
@@ -1,0 +1,3 @@
+_G["validate"] = function()
+  return nil, "this is invalid JSON"
+end


### PR DESCRIPTION
Right now, if an unexpected error like a panic happens during plugins validation via goks, an Internal Error is returned to the user with no explanation about the nature of the error. For example:

```
{
    "code": 9,
    "message": "unmarshal kong plugin validation error: invalid character 'r' looking for beginning of value"
}
```

This commit makes sure Koko logs the original error and returns a slightly nicer 400 to the user, like:

```
{
    "code": 3,
    "details": [
        {
            "@type": "type.googleapis.com/kong.admin.model.v1.ErrorDetail",
            "messages": [
                "(ip-restriction) unknown plugin validation error, please file a bug with Kong Inc"
            ]
        }
    ],
    "message": "validation error"
}
```