### PR TITLE
fix: correct compose type

### DIFF
--- a/docs/assets/docker-compose.yml
+++ b/docs/assets/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     image: "kong/koko:latest"
     command: "serve"
     environment:
-      KOKO_DATABASE_SQLITE_IN_MEMORY: true
+      KOKO_DATABASE_SQLITE_IN_MEMORY: "true"
       KOKO_CONTROL_SERVER_TLS_CERT_PATH: "/certs/cluster.crt"
       KOKO_CONTROL_SERVER_TLS_KEY_PATH: "/certs/cluster.key"
     restart: on-failure:3


### PR DESCRIPTION
Use a "true" string instead of a boolean in compose environment.

Makes YAML less unhappy about:

```
 $ docker-compose up     
ERROR: The Compose file './docker-compose.yml' is invalid because:
services.koko.environment.KOKO_DATABASE_SQLITE_IN_MEMORY contains true, which is an invalid type, it should be a string, number, or a null
```