### PR TITLE
fix: conditionally ignore empty value updates

### DIFF
--- a/internal/server/kong/ws/config/compat/compatibility_table.go
+++ b/internal/server/kong/ws/config/compat/compatibility_table.go
@@ -603,6 +603,7 @@ var (
 							{
 								Field:          "access",
 								ValueFromField: "functions",
+								IgnoreEmpty:    true,
 							},
 							{
 								Field: "functions",
@@ -636,6 +637,7 @@ var (
 							{
 								Field:          "access",
 								ValueFromField: "functions",
+								IgnoreEmpty:    true,
 							},
 							{
 								Field: "functions",

--- a/internal/server/kong/ws/config/compat/compatibility_table.go
+++ b/internal/server/kong/ws/config/compat/compatibility_table.go
@@ -601,9 +601,9 @@ var (
 						Condition: "functions",
 						Updates: []config.ConfigTableFieldUpdate{
 							{
-								Field:          "access",
-								ValueFromField: "functions",
-								IgnoreEmpty:    true,
+								Field:            "access",
+								ValueFromField:   "functions",
+								FieldMustBeEmpty: true,
 							},
 							{
 								Field: "functions",
@@ -635,9 +635,9 @@ var (
 						Condition: "functions",
 						Updates: []config.ConfigTableFieldUpdate{
 							{
-								Field:          "access",
-								ValueFromField: "functions",
-								IgnoreEmpty:    true,
+								Field:            "access",
+								ValueFromField:   "functions",
+								FieldMustBeEmpty: true,
 							},
 							{
 								Field: "functions",

--- a/internal/server/kong/ws/config/compat/compatibility_table.go
+++ b/internal/server/kong/ws/config/compat/compatibility_table.go
@@ -836,6 +836,42 @@ var (
 				},
 			},
 		},
+		{
+			Metadata: config.ChangeMetadata{
+				ID:       config.ChangeID("P135"),
+				Severity: config.ChangeSeverityWarning,
+				Description: "For the 'pre-function' plugin, " +
+					"'config.functions' field has been used. " +
+					"This field is deprecated and it is no longer supported " +
+					"in Kong Gateway versions >= 3.0.",
+				Resolution: "Please update the plugin configuration to use " +
+					"'config.access' field in place of 'config.functions' field",
+			},
+			SemverRange: versions300AndAbove,
+			Update: config.ConfigTableUpdates{
+				Name:         "pre-function",
+				Type:         config.Plugin,
+				RemoveFields: []string{"functions"},
+			},
+		},
+		{
+			Metadata: config.ChangeMetadata{
+				ID:       config.ChangeID("P136"),
+				Severity: config.ChangeSeverityWarning,
+				Description: "For the 'post-function' plugin, " +
+					"'config.functions' field has been used. " +
+					"This field is deprecated and it is no longer supported " +
+					"in Kong Gateway versions >= 3.0.",
+				Resolution: "Please update the plugin configuration to use " +
+					"'config.access' field in place of 'config.functions' field",
+			},
+			SemverRange: versions300AndAbove,
+			Update: config.ConfigTableUpdates{
+				Name:         "post-function",
+				Type:         config.Plugin,
+				RemoveFields: []string{"functions"},
+			},
+		},
 	}
 )
 

--- a/internal/server/kong/ws/config/compat/compatibility_table.go
+++ b/internal/server/kong/ws/config/compat/compatibility_table.go
@@ -595,6 +595,11 @@ var (
 			Update: config.ConfigTableUpdates{
 				Name: "pre-function",
 				Type: config.Plugin,
+				DisableChangeTracking: func(rawJSON string) bool {
+					// do not emit change if functions is set to default value (empty array)
+					plugin := gjson.Parse(rawJSON)
+					return config.ValueIsEmpty(plugin.Get("config.functions"))
+				},
 				FieldUpdates: []config.ConfigTableFieldCondition{
 					{
 						Field:     "functions",
@@ -629,6 +634,11 @@ var (
 			Update: config.ConfigTableUpdates{
 				Name: "post-function",
 				Type: config.Plugin,
+				DisableChangeTracking: func(rawJSON string) bool {
+					// do not emit change if functions is set to default value (empty array)
+					plugin := gjson.Parse(rawJSON)
+					return config.ValueIsEmpty(plugin.Get("config.functions"))
+				},
 				FieldUpdates: []config.ConfigTableFieldCondition{
 					{
 						Field:     "functions",

--- a/internal/server/kong/ws/config/compat/compatibility_table.go
+++ b/internal/server/kong/ws/config/compat/compatibility_table.go
@@ -836,48 +836,6 @@ var (
 				},
 			},
 		},
-		{
-			Metadata: config.ChangeMetadata{
-				ID:       config.ChangeID("P135"),
-				Severity: config.ChangeSeverityError,
-				Description: standardPluginFieldsMessage("pre-function",
-					[]string{"functions"}, "3.0", true),
-				Resolution: "Please update the plugin configuration to use " +
-					"'config.access' field in place of 'config.functions' field",
-			},
-			SemverRange: versions300AndAbove,
-			Update: config.ConfigTableUpdates{
-				Name:         "pre-function",
-				Type:         config.Plugin,
-				RemoveFields: []string{"functions"},
-				DisableChangeTracking: func(rawJSON string) bool {
-					// do not emit change if functions is set to default value (empty array)
-					plugin := gjson.Parse(rawJSON)
-					return len(plugin.Get("config.functions").Array()) == 0
-				},
-			},
-		},
-		{
-			Metadata: config.ChangeMetadata{
-				ID:       config.ChangeID("P136"),
-				Severity: config.ChangeSeverityError,
-				Description: standardPluginFieldsMessage("post-function",
-					[]string{"functions"}, "3.0", true),
-				Resolution: "Please update the plugin configuration to use " +
-					"'config.access' field in place of 'config.functions' field",
-			},
-			SemverRange: versions300AndAbove,
-			Update: config.ConfigTableUpdates{
-				Name:         "post-function",
-				Type:         config.Plugin,
-				RemoveFields: []string{"functions"},
-				DisableChangeTracking: func(rawJSON string) bool {
-					// do not emit change if functions is set to default value (empty array)
-					plugin := gjson.Parse(rawJSON)
-					return len(plugin.Get("config.functions").Array()) == 0
-				},
-			},
-		},
 	}
 )
 

--- a/internal/server/kong/ws/config/compat/compatibility_table.go
+++ b/internal/server/kong/ws/config/compat/compatibility_table.go
@@ -839,7 +839,7 @@ var (
 		{
 			Metadata: config.ChangeMetadata{
 				ID:       config.ChangeID("P135"),
-				Severity: config.ChangeSeverityWarning,
+				Severity: config.ChangeSeverityError,
 				Description: standardPluginFieldsMessage("pre-function",
 					[]string{"functions"}, "3.0", true),
 				Resolution: "Please update the plugin configuration to use " +
@@ -850,12 +850,17 @@ var (
 				Name:         "pre-function",
 				Type:         config.Plugin,
 				RemoveFields: []string{"functions"},
+				DisableChangeTracking: func(rawJSON string) bool {
+					// do not emit change if functions is set to default value (empty array)
+					plugin := gjson.Parse(rawJSON)
+					return len(plugin.Get("config.functions").Array()) == 0
+				},
 			},
 		},
 		{
 			Metadata: config.ChangeMetadata{
 				ID:       config.ChangeID("P136"),
-				Severity: config.ChangeSeverityWarning,
+				Severity: config.ChangeSeverityError,
 				Description: standardPluginFieldsMessage("post-function",
 					[]string{"functions"}, "3.0", true),
 				Resolution: "Please update the plugin configuration to use " +
@@ -866,6 +871,11 @@ var (
 				Name:         "post-function",
 				Type:         config.Plugin,
 				RemoveFields: []string{"functions"},
+				DisableChangeTracking: func(rawJSON string) bool {
+					// do not emit change if functions is set to default value (empty array)
+					plugin := gjson.Parse(rawJSON)
+					return len(plugin.Get("config.functions").Array()) == 0
+				},
 			},
 		},
 	}

--- a/internal/server/kong/ws/config/compat/compatibility_table.go
+++ b/internal/server/kong/ws/config/compat/compatibility_table.go
@@ -840,10 +840,8 @@ var (
 			Metadata: config.ChangeMetadata{
 				ID:       config.ChangeID("P135"),
 				Severity: config.ChangeSeverityWarning,
-				Description: "For the 'pre-function' plugin, " +
-					"'config.functions' field has been used. " +
-					"This field is deprecated and it is no longer supported " +
-					"in Kong Gateway versions >= 3.0.",
+				Description: standardPluginFieldsMessage("pre-function",
+					[]string{"functions"}, "3.0", true),
 				Resolution: "Please update the plugin configuration to use " +
 					"'config.access' field in place of 'config.functions' field",
 			},
@@ -858,10 +856,8 @@ var (
 			Metadata: config.ChangeMetadata{
 				ID:       config.ChangeID("P136"),
 				Severity: config.ChangeSeverityWarning,
-				Description: "For the 'post-function' plugin, " +
-					"'config.functions' field has been used. " +
-					"This field is deprecated and it is no longer supported " +
-					"in Kong Gateway versions >= 3.0.",
+				Description: standardPluginFieldsMessage("post-function",
+					[]string{"functions"}, "3.0", true),
 				Resolution: "Please update the plugin configuration to use " +
 					"'config.access' field in place of 'config.functions' field",
 			},

--- a/internal/server/kong/ws/config/version_compatibility.go
+++ b/internal/server/kong/ws/config/version_compatibility.go
@@ -696,21 +696,21 @@ func shouldTrackChange(updates ConfigTableUpdates, entityJSON string) bool {
 
 // valueIsEmpty returns true to indicate a given gjson Result is considered
 // "empty". Empty for a given type is when the type is:
-//   - an Object containing no items
-//   - a Value that is nil (represents JSON value of null)
+//   - any null JSON value
+//   - an object containing no items
 //   - an array of zero length
 //   - an empty string
 func valueIsEmpty(value gjson.Result) bool {
+	if value.Type == gjson.Null {
+		return true
+	}
+
 	if value.IsObject() {
 		return len(value.Map()) == 0
 	}
 
 	if value.IsArray() {
 		return len(value.Array()) == 0
-	}
-
-	if value.Value() == nil {
-		return true
 	}
 
 	if value.String() == "" {

--- a/internal/server/kong/ws/config/version_compatibility.go
+++ b/internal/server/kong/ws/config/version_compatibility.go
@@ -388,7 +388,7 @@ func (vc *WSVersionCompatibility) processPluginUpdates(payload string,
 					if gjson.Get(updatedRaw, conditionField).Exists() {
 						for _, fieldUpdate := range update.Updates {
 							if fieldUpdate.IgnoreEmpty && fieldIsEmpty(gjson.Get(updatedRaw, configField)) {
-								continue
+								break
 							}
 
 							conditionUpdate := fmt.Sprintf("config.%s", fieldUpdate.Field)
@@ -698,13 +698,12 @@ func fieldIsEmpty(field gjson.Result) bool {
 		return len(field.Array()) == 0
 	}
 
-	if field.String() == "" {
-		return true
-	}
-
 	if field.Value() == nil {
 		return true
 	}
 
+	if field.String() == "" {
+		return true
+	}
 	return false
 }

--- a/internal/server/kong/ws/config/version_compatibility.go
+++ b/internal/server/kong/ws/config/version_compatibility.go
@@ -392,7 +392,6 @@ func (vc *WSVersionCompatibility) processPluginUpdates(payload string,
 							if fieldUpdate.IgnoreEmpty && fieldIsEmpty(gjson.Get(updatedRaw, configField)) {
 								break
 							}
-
 							conditionUpdate := fmt.Sprintf("config.%s", fieldUpdate.Field)
 							if fieldUpdate.Value == nil && len(fieldUpdate.ValueFromField) == 0 {
 								// Handle field removal
@@ -576,6 +575,9 @@ func (vc *WSVersionCompatibility) processCoreEntityUpdates(payload string,
 				conditionField := fmt.Sprintf("[@this].#(%s)", update.Condition)
 				if gjson.Get(updatedRaw, conditionField).Exists() {
 					for _, fieldUpdate := range update.Updates {
+						if fieldUpdate.IgnoreEmpty && fieldIsEmpty(gjson.Get(updatedRaw, configField)) {
+							break
+						}
 						conditionUpdate := fieldUpdate.Field
 						if fieldUpdate.Value == nil && len(fieldUpdate.ValueFromField) == 0 {
 							// Handle field removal

--- a/internal/server/kong/ws/config/version_compatibility.go
+++ b/internal/server/kong/ws/config/version_compatibility.go
@@ -392,8 +392,6 @@ func (vc *WSVersionCompatibility) processPluginUpdates(payload string,
 							conditionUpdate := fmt.Sprintf("config.%s", fieldUpdate.Field)
 							// Ensure the original field is not empty if specified; do not overwrite
 							if fieldUpdate.FieldMustBeEmpty && !ValueIsEmpty(gjson.Get(updatedRaw, conditionUpdate)) {
-								// Since this is a copy function from another field and the current field is already
-								// configured the entire field update process should short circuit
 								continue
 							}
 
@@ -573,7 +571,6 @@ func (vc *WSVersionCompatibility) processCoreEntityUpdates(payload string,
 
 		// Field update
 		for _, update := range configTableUpdate.FieldUpdates {
-			fmt.Println("update: ", update)
 			configField := update.Field
 			if gjson.Get(updatedRaw, configField).Exists() {
 				conditionField := fmt.Sprintf("[@this].#(%s)", update.Condition)

--- a/internal/server/kong/ws/config/version_compatibility.go
+++ b/internal/server/kong/ws/config/version_compatibility.go
@@ -395,7 +395,7 @@ func (vc *WSVersionCompatibility) processPluginUpdates(payload string,
 							if fieldUpdate.FieldMustBeEmpty && !valueIsEmpty(gjson.Get(updatedRaw, conditionUpdate)) {
 								// Since this is a copy function from another field and the current field is already
 								// configured the entire field update process should short circuit
-								break
+								continue
 							}
 
 							if fieldUpdate.Value == nil && len(fieldUpdate.ValueFromField) == 0 {

--- a/internal/server/kong/ws/config/version_compatibility.go
+++ b/internal/server/kong/ws/config/version_compatibility.go
@@ -687,10 +687,10 @@ func shouldTrackChange(updates ConfigTableUpdates, entityJSON string) bool {
 }
 
 // fieldIsEmpty checks if a given field is one of:
-//   - Object with no nested items
-//   - Type is null
+//   - Object with no items
+//   - Value is null
 //   - Zero length array
-//   - Zero length string
+//   - Empty string
 func fieldIsEmpty(field gjson.Result) bool {
 	if field.IsObject() {
 		return len(field.Map()) == 0

--- a/internal/server/kong/ws/config/version_compatibility.go
+++ b/internal/server/kong/ws/config/version_compatibility.go
@@ -61,7 +61,9 @@ type ConfigTableFieldUpdate struct {
 	// ValueFromField when specified represents the name of the key whose value is
 	// retrieved and applied to the key referenced in the member Field.
 	ValueFromField string
-	IgnoreEmpty    bool
+	// IgnoreEmpty indicates whether an empty value should be ignored when processing
+	// updates so that default values don't overwrite existing target values.
+	IgnoreEmpty bool
 }
 
 //nolint:revive

--- a/internal/server/kong/ws/config/version_compatibility_test.go
+++ b/internal/server/kong/ws/config/version_compatibility_test.go
@@ -5459,6 +5459,10 @@ func TestVersionCompatibility_ProcessConfigTableUpdates(t *testing.T) {
 					{
 						Name: "plugin_1",
 						Type: Plugin,
+						DisableChangeTracking: func(rawJSON string) bool {
+							plugin := gjson.Parse(rawJSON)
+							return ValueIsEmpty(plugin.Get("config.plugin_field_1"))
+						},
 						FieldUpdates: []ConfigTableFieldCondition{
 							{
 								Field:     "plugin_field_1",
@@ -5476,14 +5480,6 @@ func TestVersionCompatibility_ProcessConfigTableUpdates(t *testing.T) {
 							},
 						},
 						ChangeID: "T101",
-					},
-					{
-						Name: "plugin_1",
-						Type: Plugin,
-						RemoveFields: []string{
-							"plugin_field_1",
-						},
-						ChangeID: "T102",
 					},
 				},
 			},
@@ -5536,6 +5532,10 @@ func TestVersionCompatibility_ProcessConfigTableUpdates(t *testing.T) {
 					{
 						Name: "plugin_1",
 						Type: Plugin,
+						DisableChangeTracking: func(rawJSON string) bool {
+							plugin := gjson.Parse(rawJSON)
+							return ValueIsEmpty(plugin.Get("config.plugin_field_1"))
+						},
 						FieldUpdates: []ConfigTableFieldCondition{
 							{
 								Field:     "plugin_field_1",
@@ -5605,6 +5605,10 @@ func TestVersionCompatibility_ProcessConfigTableUpdates(t *testing.T) {
 					{
 						Name: "plugin_1",
 						Type: Plugin,
+						DisableChangeTracking: func(rawJSON string) bool {
+							plugin := gjson.Parse(rawJSON)
+							return ValueIsEmpty(plugin.Get("config.plugin_field_1"))
+						},
 						FieldUpdates: []ConfigTableFieldCondition{
 							{
 								Field:     "plugin_field_1",
@@ -5653,19 +5657,7 @@ func TestVersionCompatibility_ProcessConfigTableUpdates(t *testing.T) {
 					]
 				}
 			}`,
-			expectedChanges: TrackedChanges{
-				ChangeDetails: []ChangeDetail{
-					{
-						ID: "T101",
-						Resources: []ResourceInfo{
-							{
-								Type: "plugin",
-								ID:   "759c0d3a-bc3d-4ccc-8d4d-f92de95c1f1a",
-							},
-						},
-					},
-				},
-			},
+			expectedChanges: TrackedChanges{},
 		},
 		{
 			name: "field updates conditionally ignore empty objects",
@@ -5674,6 +5666,10 @@ func TestVersionCompatibility_ProcessConfigTableUpdates(t *testing.T) {
 					{
 						Name: "plugin_1",
 						Type: Plugin,
+						DisableChangeTracking: func(rawJSON string) bool {
+							plugin := gjson.Parse(rawJSON)
+							return ValueIsEmpty(plugin.Get("config.plugin_field_1"))
+						},
 						FieldUpdates: []ConfigTableFieldCondition{
 							{
 								Field:     "plugin_field_1",
@@ -5722,19 +5718,7 @@ func TestVersionCompatibility_ProcessConfigTableUpdates(t *testing.T) {
 					]
 				}
 			}`,
-			expectedChanges: TrackedChanges{
-				ChangeDetails: []ChangeDetail{
-					{
-						ID: "T101",
-						Resources: []ResourceInfo{
-							{
-								Type: "plugin",
-								ID:   "759c0d3a-bc3d-4ccc-8d4d-f92de95c1f1a",
-							},
-						},
-					},
-				},
-			},
+			expectedChanges: TrackedChanges{},
 		},
 		{
 			name: "field updates conditionally ignore empty strings",
@@ -5743,6 +5727,10 @@ func TestVersionCompatibility_ProcessConfigTableUpdates(t *testing.T) {
 					{
 						Name: "plugin_1",
 						Type: Plugin,
+						DisableChangeTracking: func(rawJSON string) bool {
+							plugin := gjson.Parse(rawJSON)
+							return ValueIsEmpty(plugin.Get("config.plugin_field_1"))
+						},
 						FieldUpdates: []ConfigTableFieldCondition{
 							{
 								Field:     "plugin_field_1",
@@ -5791,19 +5779,7 @@ func TestVersionCompatibility_ProcessConfigTableUpdates(t *testing.T) {
 					]
 				}
 			}`,
-			expectedChanges: TrackedChanges{
-				ChangeDetails: []ChangeDetail{
-					{
-						ID: "T101",
-						Resources: []ResourceInfo{
-							{
-								Type: "plugin",
-								ID:   "759c0d3a-bc3d-4ccc-8d4d-f92de95c1f1a",
-							},
-						},
-					},
-				},
-			},
+			expectedChanges: TrackedChanges{},
 		},
 		{
 			name: "field updates conditionally ignore nil values",
@@ -5812,6 +5788,10 @@ func TestVersionCompatibility_ProcessConfigTableUpdates(t *testing.T) {
 					{
 						Name: "plugin_1",
 						Type: Plugin,
+						DisableChangeTracking: func(rawJSON string) bool {
+							plugin := gjson.Parse(rawJSON)
+							return ValueIsEmpty(plugin.Get("config.plugin_field_1"))
+						},
 						FieldUpdates: []ConfigTableFieldCondition{
 							{
 								Field:     "plugin_field_1",
@@ -5860,19 +5840,7 @@ func TestVersionCompatibility_ProcessConfigTableUpdates(t *testing.T) {
 					]
 				}
 			}`,
-			expectedChanges: TrackedChanges{
-				ChangeDetails: []ChangeDetail{
-					{
-						ID: "T101",
-						Resources: []ResourceInfo{
-							{
-								Type: "plugin",
-								ID:   "759c0d3a-bc3d-4ccc-8d4d-f92de95c1f1a",
-							},
-						},
-					},
-				},
-			},
+			expectedChanges: TrackedChanges{},
 		},
 		{
 			name: "field updates do not create new fields when ignoring empty array values",
@@ -5881,6 +5849,10 @@ func TestVersionCompatibility_ProcessConfigTableUpdates(t *testing.T) {
 					{
 						Name: "plugin_1",
 						Type: Plugin,
+						DisableChangeTracking: func(rawJSON string) bool {
+							plugin := gjson.Parse(rawJSON)
+							return ValueIsEmpty(plugin.Get("config.plugin_field_1"))
+						},
 						FieldUpdates: []ConfigTableFieldCondition{
 							{
 								Field:     "plugin_field_1",
@@ -5898,19 +5870,6 @@ func TestVersionCompatibility_ProcessConfigTableUpdates(t *testing.T) {
 							},
 						},
 						ChangeID: "T101",
-					},
-					{
-						Name: "plugin_1",
-						Type: Plugin,
-						RemoveFields: []string{
-							"plugin_field_1",
-						},
-						DisableChangeTracking: func(rawJSON string) bool {
-							// do not emit change if functions is set to default value (empty array)
-							plugin := gjson.Parse(rawJSON)
-							return len(plugin.Get("config.plugin_field_1").Array()) == 0
-						},
-						ChangeID: "T102",
 					},
 				},
 			},
@@ -5942,12 +5901,16 @@ func TestVersionCompatibility_ProcessConfigTableUpdates(t *testing.T) {
 			expectedChanges: TrackedChanges{},
 		},
 		{
-			name: "field updates conditionally ignore empty arrays",
+			name: "core field updates conditionally ignore empty arrays",
 			configTableUpdates: map[string][]ConfigTableUpdates{
 				">= 3.0.0": {
 					{
 						Name: "plugin_1",
 						Type: CorePlugin,
+						DisableChangeTracking: func(rawJSON string) bool {
+							plugin := gjson.Parse(rawJSON)
+							return ValueIsEmpty(plugin.Get("plugin_field_1"))
+						},
 						FieldUpdates: []ConfigTableFieldCondition{
 							{
 								Field:     "plugin_field_1",
@@ -5965,14 +5928,6 @@ func TestVersionCompatibility_ProcessConfigTableUpdates(t *testing.T) {
 							},
 						},
 						ChangeID: "T101",
-					},
-					{
-						Name: "plugin_1",
-						Type: CorePlugin,
-						RemoveFields: []string{
-							"plugin_field_1",
-						},
-						ChangeID: "T102",
 					},
 				},
 			},
@@ -6000,27 +5955,19 @@ func TestVersionCompatibility_ProcessConfigTableUpdates(t *testing.T) {
 					]
 				}
 			}`,
-			expectedChanges: TrackedChanges{
-				ChangeDetails: []ChangeDetail{
-					{
-						ID: "T102",
-						Resources: []ResourceInfo{
-							{
-								Type: "plugin",
-								ID:   "759c0d3a-bc3d-4ccc-8d4d-f92de95c1f1a",
-							},
-						},
-					},
-				},
-			},
+			expectedChanges: TrackedChanges{},
 		},
 		{
-			name: "field updates conditionally ignore empty objects",
+			name: "core field updates conditionally ignore empty objects",
 			configTableUpdates: map[string][]ConfigTableUpdates{
 				">= 3.0.0": {
 					{
 						Name: "plugin_1",
 						Type: CorePlugin,
+						DisableChangeTracking: func(rawJSON string) bool {
+							plugin := gjson.Parse(rawJSON)
+							return ValueIsEmpty(plugin.Get("plugin_field_1"))
+						},
 						FieldUpdates: []ConfigTableFieldCondition{
 							{
 								Field:     "plugin_field_1",
@@ -6038,14 +5985,6 @@ func TestVersionCompatibility_ProcessConfigTableUpdates(t *testing.T) {
 							},
 						},
 						ChangeID: "T101",
-					},
-					{
-						Name: "plugin_1",
-						Type: CorePlugin,
-						RemoveFields: []string{
-							"plugin_field_1",
-						},
-						ChangeID: "T102",
 					},
 				},
 			},
@@ -6073,27 +6012,19 @@ func TestVersionCompatibility_ProcessConfigTableUpdates(t *testing.T) {
 					]
 				}
 			}`,
-			expectedChanges: TrackedChanges{
-				ChangeDetails: []ChangeDetail{
-					{
-						ID: "T102",
-						Resources: []ResourceInfo{
-							{
-								Type: "plugin",
-								ID:   "759c0d3a-bc3d-4ccc-8d4d-f92de95c1f1a",
-							},
-						},
-					},
-				},
-			},
+			expectedChanges: TrackedChanges{},
 		},
 		{
-			name: "field updates conditionally ignore empty strings",
+			name: "core field updates conditionally ignore empty strings",
 			configTableUpdates: map[string][]ConfigTableUpdates{
 				">= 3.0.0": {
 					{
 						Name: "plugin_1",
 						Type: CorePlugin,
+						DisableChangeTracking: func(rawJSON string) bool {
+							plugin := gjson.Parse(rawJSON)
+							return ValueIsEmpty(plugin.Get("plugin_field_1"))
+						},
 						FieldUpdates: []ConfigTableFieldCondition{
 							{
 								Field:     "plugin_field_1",
@@ -6111,14 +6042,6 @@ func TestVersionCompatibility_ProcessConfigTableUpdates(t *testing.T) {
 							},
 						},
 						ChangeID: "T101",
-					},
-					{
-						Name: "plugin_1",
-						Type: CorePlugin,
-						RemoveFields: []string{
-							"plugin_field_1",
-						},
-						ChangeID: "T102",
 					},
 				},
 			},
@@ -6146,27 +6069,19 @@ func TestVersionCompatibility_ProcessConfigTableUpdates(t *testing.T) {
 					]
 				}
 			}`,
-			expectedChanges: TrackedChanges{
-				ChangeDetails: []ChangeDetail{
-					{
-						ID: "T102",
-						Resources: []ResourceInfo{
-							{
-								Type: "plugin",
-								ID:   "759c0d3a-bc3d-4ccc-8d4d-f92de95c1f1a",
-							},
-						},
-					},
-				},
-			},
+			expectedChanges: TrackedChanges{},
 		},
 		{
-			name: "field updates conditionally ignore nil values",
+			name: "core field updates conditionally ignore nil values",
 			configTableUpdates: map[string][]ConfigTableUpdates{
 				">= 3.0.0": {
 					{
 						Name: "plugin_1",
 						Type: CorePlugin,
+						DisableChangeTracking: func(rawJSON string) bool {
+							plugin := gjson.Parse(rawJSON)
+							return ValueIsEmpty(plugin.Get("plugin_field_1"))
+						},
 						FieldUpdates: []ConfigTableFieldCondition{
 							{
 								Field:     "plugin_field_1",
@@ -6184,14 +6099,6 @@ func TestVersionCompatibility_ProcessConfigTableUpdates(t *testing.T) {
 							},
 						},
 						ChangeID: "T101",
-					},
-					{
-						Name: "plugin_1",
-						Type: CorePlugin,
-						RemoveFields: []string{
-							"plugin_field_1",
-						},
-						ChangeID: "T102",
 					},
 				},
 			},
@@ -6219,27 +6126,19 @@ func TestVersionCompatibility_ProcessConfigTableUpdates(t *testing.T) {
 					]
 				}
 			}`,
-			expectedChanges: TrackedChanges{
-				ChangeDetails: []ChangeDetail{
-					{
-						ID: "T102",
-						Resources: []ResourceInfo{
-							{
-								Type: "plugin",
-								ID:   "759c0d3a-bc3d-4ccc-8d4d-f92de95c1f1a",
-							},
-						},
-					},
-				},
-			},
+			expectedChanges: TrackedChanges{},
 		},
 		{
-			name: "field updates do not create new fields when ignoring empty array values",
+			name: "core field updates do not create new fields when ignoring empty array values",
 			configTableUpdates: map[string][]ConfigTableUpdates{
 				">= 3.0.0": {
 					{
 						Name: "plugin_1",
 						Type: CorePlugin,
+						DisableChangeTracking: func(rawJSON string) bool {
+							plugin := gjson.Parse(rawJSON)
+							return ValueIsEmpty(plugin.Get("plugin_field_1"))
+						},
 						FieldUpdates: []ConfigTableFieldCondition{
 							{
 								Field:     "plugin_field_1",
@@ -6257,19 +6156,6 @@ func TestVersionCompatibility_ProcessConfigTableUpdates(t *testing.T) {
 							},
 						},
 						ChangeID: "T101",
-					},
-					{
-						Name: "plugin_1",
-						Type: CorePlugin,
-						RemoveFields: []string{
-							"plugin_field_1",
-						},
-						DisableChangeTracking: func(rawJSON string) bool {
-							// do not emit change if functions is set to default value (empty array)
-							plugin := gjson.Parse(rawJSON)
-							return len(plugin.Get("config.plugin_field_1").Array()) == 0
-						},
-						ChangeID: "T102",
 					},
 				},
 			},
@@ -6496,7 +6382,7 @@ func TestVersionCompatibility_ValueIsEmpty(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			require.Equal(t, test.expectedValue, valueIsEmpty(gjson.Get(test.rawJSON, "value")))
+			require.Equal(t, test.expectedValue, ValueIsEmpty(gjson.Get(test.rawJSON, "value")))
 		})
 	}
 }

--- a/internal/server/kong/ws/config/version_compatibility_test.go
+++ b/internal/server/kong/ws/config/version_compatibility_test.go
@@ -5452,7 +5452,7 @@ func TestVersionCompatibility_ProcessConfigTableUpdates(t *testing.T) {
 			}`,
 		},
 		{
-			name: "conditionally ignores empty value updates",
+			name: "updates conditionally ignores empty arrays",
 			configTableUpdates: map[string][]ConfigTableUpdates{
 				">= 3.0.0": {
 					{
@@ -5475,6 +5475,14 @@ func TestVersionCompatibility_ProcessConfigTableUpdates(t *testing.T) {
 							},
 						},
 						ChangeID: "T101",
+					},
+					{
+						Name: "plugin_1",
+						Type: Plugin,
+						RemoveFields: []string{
+							"plugin_field_1",
+						},
+						ChangeID: "T102",
 					},
 				},
 			},
@@ -5513,7 +5521,328 @@ func TestVersionCompatibility_ProcessConfigTableUpdates(t *testing.T) {
 			expectedChanges: TrackedChanges{
 				ChangeDetails: []ChangeDetail{
 					{
-						ID: "T101",
+						ID: "T102",
+						Resources: []ResourceInfo{
+							{
+								Type: "plugin",
+								ID:   "759c0d3a-bc3d-4ccc-8d4d-f92de95c1f1a",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "updates conditionally ignores empty objects",
+			configTableUpdates: map[string][]ConfigTableUpdates{
+				">= 3.0.0": {
+					{
+						Name: "plugin_1",
+						Type: Plugin,
+						FieldUpdates: []ConfigTableFieldCondition{
+							{
+								Field:     "plugin_field_1",
+								Condition: "plugin_field_1",
+								Updates: []ConfigTableFieldUpdate{
+									{
+										Field:          "plugin_field_2",
+										ValueFromField: "plugin_field_1",
+										IgnoreEmpty:    true,
+									},
+									{
+										Field: "plugin_field_1",
+									},
+								},
+							},
+						},
+						ChangeID: "T101",
+					},
+					{
+						Name: "plugin_1",
+						Type: Plugin,
+						RemoveFields: []string{
+							"plugin_field_1",
+						},
+						ChangeID: "T102",
+					},
+				},
+			},
+			uncompressedPayload: `
+		{
+			"config_table": {
+				"plugins": [
+					{
+						"id": "759c0d3a-bc3d-4ccc-8d4d-f92de95c1f1a",
+						"name": "plugin_1",
+						"config": {
+							"plugin_field_1": {},
+							"plugin_field_2": { "foo": "bar" }
+						}
+					}
+				]
+			}
+		}
+		`,
+			dataPlaneVersion: "3.0.0",
+			expectedPayload: `
+		{
+			"config_table": {
+				"plugins": [
+					{
+						"id": "759c0d3a-bc3d-4ccc-8d4d-f92de95c1f1a",
+						"name": "plugin_1",
+						"config": {
+							"plugin_field_2": { "foo": "bar" }
+						}
+					}
+				]
+			}
+		}
+		`,
+			expectedChanges: TrackedChanges{
+				ChangeDetails: []ChangeDetail{
+					{
+						ID: "T102",
+						Resources: []ResourceInfo{
+							{
+								Type: "plugin",
+								ID:   "759c0d3a-bc3d-4ccc-8d4d-f92de95c1f1a",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "updates conditionally ignores empty strings",
+			configTableUpdates: map[string][]ConfigTableUpdates{
+				">= 3.0.0": {
+					{
+						Name: "plugin_1",
+						Type: Plugin,
+						FieldUpdates: []ConfigTableFieldCondition{
+							{
+								Field:     "plugin_field_1",
+								Condition: "plugin_field_1",
+								Updates: []ConfigTableFieldUpdate{
+									{
+										Field:          "plugin_field_2",
+										ValueFromField: "plugin_field_1",
+										IgnoreEmpty:    true,
+									},
+									{
+										Field: "plugin_field_1",
+									},
+								},
+							},
+						},
+						ChangeID: "T101",
+					},
+					{
+						Name: "plugin_1",
+						Type: Plugin,
+						RemoveFields: []string{
+							"plugin_field_1",
+						},
+						ChangeID: "T102",
+					},
+				},
+			},
+			uncompressedPayload: `
+		{
+			"config_table": {
+				"plugins": [
+					{
+						"id": "759c0d3a-bc3d-4ccc-8d4d-f92de95c1f1a",
+						"name": "plugin_1",
+						"config": {
+							"plugin_field_1": "",
+							"plugin_field_2": "foo"
+						}
+					}
+				]
+			}
+		}
+		`,
+			dataPlaneVersion: "3.0.0",
+			expectedPayload: `
+		{
+			"config_table": {
+				"plugins": [
+					{
+						"id": "759c0d3a-bc3d-4ccc-8d4d-f92de95c1f1a",
+						"name": "plugin_1",
+						"config": {
+							"plugin_field_2": "foo"
+						}
+					}
+				]
+			}
+		}
+		`,
+			expectedChanges: TrackedChanges{
+				ChangeDetails: []ChangeDetail{
+					{
+						ID: "T102",
+						Resources: []ResourceInfo{
+							{
+								Type: "plugin",
+								ID:   "759c0d3a-bc3d-4ccc-8d4d-f92de95c1f1a",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "updates conditionally ignores nil values",
+			configTableUpdates: map[string][]ConfigTableUpdates{
+				">= 3.0.0": {
+					{
+						Name: "plugin_1",
+						Type: Plugin,
+						FieldUpdates: []ConfigTableFieldCondition{
+							{
+								Field:     "plugin_field_1",
+								Condition: "plugin_field_1",
+								Updates: []ConfigTableFieldUpdate{
+									{
+										Field:          "plugin_field_2",
+										ValueFromField: "plugin_field_1",
+										IgnoreEmpty:    true,
+									},
+									{
+										Field: "plugin_field_1",
+									},
+								},
+							},
+						},
+						ChangeID: "T101",
+					},
+					{
+						Name: "plugin_1",
+						Type: Plugin,
+						RemoveFields: []string{
+							"plugin_field_1",
+						},
+						ChangeID: "T102",
+					},
+				},
+			},
+			uncompressedPayload: `
+		{
+			"config_table": {
+				"plugins": [
+					{
+						"id": "759c0d3a-bc3d-4ccc-8d4d-f92de95c1f1a",
+						"name": "plugin_1",
+						"config": {
+							"plugin_field_1": null,
+							"plugin_field_2": "foo"
+						}
+					}
+				]
+			}
+		}
+		`,
+			dataPlaneVersion: "3.0.0",
+			expectedPayload: `
+		{
+			"config_table": {
+				"plugins": [
+					{
+						"id": "759c0d3a-bc3d-4ccc-8d4d-f92de95c1f1a",
+						"name": "plugin_1",
+						"config": {
+							"plugin_field_2": "foo"
+						}
+					}
+				]
+			}
+		}
+		`,
+			expectedChanges: TrackedChanges{
+				ChangeDetails: []ChangeDetail{
+					{
+						ID: "T102",
+						Resources: []ResourceInfo{
+							{
+								Type: "plugin",
+								ID:   "759c0d3a-bc3d-4ccc-8d4d-f92de95c1f1a",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "does not create new fields when ignoring empty array values",
+			configTableUpdates: map[string][]ConfigTableUpdates{
+				">= 3.0.0": {
+					{
+						Name: "plugin_1",
+						Type: Plugin,
+						FieldUpdates: []ConfigTableFieldCondition{
+							{
+								Field:     "plugin_field_1",
+								Condition: "plugin_field_1",
+								Updates: []ConfigTableFieldUpdate{
+									{
+										Field:          "plugin_field_2",
+										ValueFromField: "plugin_field_1",
+										IgnoreEmpty:    true,
+									},
+									{
+										Field: "plugin_field_1",
+									},
+								},
+							},
+						},
+						ChangeID: "T101",
+					},
+					{
+						Name: "plugin_1",
+						Type: Plugin,
+						RemoveFields: []string{
+							"plugin_field_1",
+						},
+						ChangeID: "T102",
+					},
+				},
+			},
+			uncompressedPayload: `
+		{
+			"config_table": {
+				"plugins": [
+					{
+						"id": "759c0d3a-bc3d-4ccc-8d4d-f92de95c1f1a",
+						"name": "plugin_1",
+						"config": {
+							"plugin_field_1": []
+						}
+					}
+				]
+			}
+		}
+		`,
+			dataPlaneVersion: "3.0.0",
+			expectedPayload: `
+		{
+			"config_table": {
+				"plugins": [
+					{
+						"id": "759c0d3a-bc3d-4ccc-8d4d-f92de95c1f1a",
+						"name": "plugin_1",
+						"config": {}
+					}
+				]
+			}
+		}
+		`,
+			expectedChanges: TrackedChanges{
+				ChangeDetails: []ChangeDetail{
+					{
+						ID: "T102",
 						Resources: []ResourceInfo{
 							{
 								Type: "plugin",

--- a/internal/server/kong/ws/config/version_compatibility_test.go
+++ b/internal/server/kong/ws/config/version_compatibility_test.go
@@ -5843,64 +5843,6 @@ func TestVersionCompatibility_ProcessConfigTableUpdates(t *testing.T) {
 			expectedChanges: TrackedChanges{},
 		},
 		{
-			name: "field updates do not create new fields when ignoring empty array values",
-			configTableUpdates: map[string][]ConfigTableUpdates{
-				">= 3.0.0": {
-					{
-						Name: "plugin_1",
-						Type: Plugin,
-						DisableChangeTracking: func(rawJSON string) bool {
-							plugin := gjson.Parse(rawJSON)
-							return ValueIsEmpty(plugin.Get("config.plugin_field_1"))
-						},
-						FieldUpdates: []ConfigTableFieldCondition{
-							{
-								Field:     "plugin_field_1",
-								Condition: "plugin_field_1",
-								Updates: []ConfigTableFieldUpdate{
-									{
-										Field:            "plugin_field_2",
-										ValueFromField:   "plugin_field_1",
-										FieldMustBeEmpty: true,
-									},
-									{
-										Field: "plugin_field_1",
-									},
-								},
-							},
-						},
-						ChangeID: "T101",
-					},
-				},
-			},
-			uncompressedPayload: `{
-				"config_table": {
-					"plugins": [
-						{
-							"id": "759c0d3a-bc3d-4ccc-8d4d-f92de95c1f1a",
-							"name": "plugin_1",
-							"config": {
-								"plugin_field_1": []
-							}
-						}
-					]
-				}
-			}`,
-			dataPlaneVersion: "3.0.0",
-			expectedPayload: `{
-				"config_table": {
-					"plugins": [
-						{
-							"id": "759c0d3a-bc3d-4ccc-8d4d-f92de95c1f1a",
-							"name": "plugin_1",
-							"config": {}
-						}
-					]
-				}
-			}`,
-			expectedChanges: TrackedChanges{},
-		},
-		{
 			name: "core field updates conditionally ignore empty arrays",
 			configTableUpdates: map[string][]ConfigTableUpdates{
 				">= 3.0.0": {
@@ -6122,61 +6064,6 @@ func TestVersionCompatibility_ProcessConfigTableUpdates(t *testing.T) {
 							"id": "759c0d3a-bc3d-4ccc-8d4d-f92de95c1f1a",
 							"name": "plugin_1",
 							"plugin_field_2": "foo"
-						}
-					]
-				}
-			}`,
-			expectedChanges: TrackedChanges{},
-		},
-		{
-			name: "core field updates do not create new fields when ignoring empty array values",
-			configTableUpdates: map[string][]ConfigTableUpdates{
-				">= 3.0.0": {
-					{
-						Name: "plugin_1",
-						Type: CorePlugin,
-						DisableChangeTracking: func(rawJSON string) bool {
-							plugin := gjson.Parse(rawJSON)
-							return ValueIsEmpty(plugin.Get("plugin_field_1"))
-						},
-						FieldUpdates: []ConfigTableFieldCondition{
-							{
-								Field:     "plugin_field_1",
-								Condition: "plugin_field_1",
-								Updates: []ConfigTableFieldUpdate{
-									{
-										Field:            "plugin_field_2",
-										ValueFromField:   "plugin_field_1",
-										FieldMustBeEmpty: true,
-									},
-									{
-										Field: "plugin_field_1",
-									},
-								},
-							},
-						},
-						ChangeID: "T101",
-					},
-				},
-			},
-			uncompressedPayload: `{
-				"config_table": {
-					"plugins": [
-						{
-							"id": "759c0d3a-bc3d-4ccc-8d4d-f92de95c1f1a",
-							"name": "plugin_1",
-							"plugin_field_1": []
-						}
-					]
-				}
-			}`,
-			dataPlaneVersion: "3.0.0",
-			expectedPayload: `{
-				"config_table": {
-					"plugins": [
-						{
-							"id": "759c0d3a-bc3d-4ccc-8d4d-f92de95c1f1a",
-							"name": "plugin_1"
 						}
 					]
 				}

--- a/internal/server/kong/ws/config/version_compatibility_test.go
+++ b/internal/server/kong/ws/config/version_compatibility_test.go
@@ -6322,3 +6322,67 @@ func TestVersionCompatibility_PerformExtraProcessing(t *testing.T) {
 		require.JSONEq(t, expectedPayload, string(uncompressedPayload))
 	})
 }
+
+func TestVersionCompatibility_ValueIsEmpty(t *testing.T) {
+	tests := []struct {
+		name          string
+		rawJSON       string
+		expectedValue bool
+	}{
+		{
+			name: "object is empty",
+			rawJSON: `{
+				"value": {}
+			}`,
+			expectedValue: true,
+		},
+		{
+			name: "object is not empty",
+			rawJSON: `{
+				"value": { "foo": "bar" }
+			}`,
+			expectedValue: false,
+		},
+		{
+			name: "string is empty",
+			rawJSON: `{
+				"value": ""
+			}`,
+			expectedValue: true,
+		},
+		{
+			name: "string is not empty",
+			rawJSON: `{
+				"value": "foo"
+			}`,
+			expectedValue: false,
+		},
+		{
+			name: "array is empty",
+			rawJSON: `{
+				"value": []
+			}`,
+			expectedValue: true,
+		},
+		{
+			name: "array is not empty",
+			rawJSON: `{
+				"value": ["foo"]
+			}`,
+			expectedValue: false,
+		},
+		{
+			name: "value is null",
+			rawJSON: `{
+				"value": null
+			}`,
+			expectedValue: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.expectedValue, valueIsEmpty(gjson.Get(test.rawJSON, "value")))
+		})
+	}
+}

--- a/internal/server/kong/ws/config/version_compatibility_test.go
+++ b/internal/server/kong/ws/config/version_compatibility_test.go
@@ -5518,7 +5518,7 @@ func TestVersionCompatibility_ProcessConfigTableUpdates(t *testing.T) {
 			expectedChanges: TrackedChanges{
 				ChangeDetails: []ChangeDetail{
 					{
-						ID: "T102",
+						ID: "T101",
 						Resources: []ResourceInfo{
 							{
 								Type: "plugin",

--- a/internal/server/kong/ws/config/version_compatibility_test.go
+++ b/internal/server/kong/ws/config/version_compatibility_test.go
@@ -5486,38 +5486,34 @@ func TestVersionCompatibility_ProcessConfigTableUpdates(t *testing.T) {
 					},
 				},
 			},
-			uncompressedPayload: `
-		{
-			"config_table": {
-				"plugins": [
-					{
-						"id": "759c0d3a-bc3d-4ccc-8d4d-f92de95c1f1a",
-						"name": "plugin_1",
-						"config": {
-							"plugin_field_1": [],
-							"plugin_field_2": ["kong.log.err('Hello Koko!')"]
+			uncompressedPayload: `{
+				"config_table": {
+					"plugins": [
+						{
+							"id": "759c0d3a-bc3d-4ccc-8d4d-f92de95c1f1a",
+							"name": "plugin_1",
+							"config": {
+								"plugin_field_1": [],
+								"plugin_field_2": ["kong.log.err('Hello Koko!')"]
+							}
 						}
-					}
-				]
-			}
-		}
-		`,
+					]
+				}
+			}`,
 			dataPlaneVersion: "3.0.0",
-			expectedPayload: `
-		{
-			"config_table": {
-				"plugins": [
-					{
-						"id": "759c0d3a-bc3d-4ccc-8d4d-f92de95c1f1a",
-						"name": "plugin_1",
-						"config": {
-							"plugin_field_2": ["kong.log.err('Hello Koko!')"]
+			expectedPayload: `{
+				"config_table": {
+					"plugins": [
+						{
+							"id": "759c0d3a-bc3d-4ccc-8d4d-f92de95c1f1a",
+							"name": "plugin_1",
+							"config": {
+								"plugin_field_2": ["kong.log.err('Hello Koko!')"]
+							}
 						}
-					}
-				]
-			}
-		}
-		`,
+					]
+				}
+			}`,
 			expectedChanges: TrackedChanges{
 				ChangeDetails: []ChangeDetail{
 					{
@@ -5567,38 +5563,34 @@ func TestVersionCompatibility_ProcessConfigTableUpdates(t *testing.T) {
 					},
 				},
 			},
-			uncompressedPayload: `
-		{
-			"config_table": {
-				"plugins": [
-					{
-						"id": "759c0d3a-bc3d-4ccc-8d4d-f92de95c1f1a",
-						"name": "plugin_1",
-						"config": {
-							"plugin_field_1": {},
-							"plugin_field_2": { "foo": "bar" }
+			uncompressedPayload: `{
+				"config_table": {
+					"plugins": [
+						{
+							"id": "759c0d3a-bc3d-4ccc-8d4d-f92de95c1f1a",
+							"name": "plugin_1",
+							"config": {
+								"plugin_field_1": {},
+								"plugin_field_2": { "foo": "bar" }
+							}
 						}
-					}
-				]
-			}
-		}
-		`,
+					]
+				}
+			}`,
 			dataPlaneVersion: "3.0.0",
-			expectedPayload: `
-		{
-			"config_table": {
-				"plugins": [
-					{
-						"id": "759c0d3a-bc3d-4ccc-8d4d-f92de95c1f1a",
-						"name": "plugin_1",
-						"config": {
-							"plugin_field_2": { "foo": "bar" }
+			expectedPayload: `{
+				"config_table": {
+					"plugins": [
+						{
+							"id": "759c0d3a-bc3d-4ccc-8d4d-f92de95c1f1a",
+							"name": "plugin_1",
+							"config": {
+								"plugin_field_2": { "foo": "bar" }
+							}
 						}
-					}
-				]
-			}
-		}
-		`,
+					]
+				}
+			}`,
 			expectedChanges: TrackedChanges{
 				ChangeDetails: []ChangeDetail{
 					{
@@ -5648,38 +5640,34 @@ func TestVersionCompatibility_ProcessConfigTableUpdates(t *testing.T) {
 					},
 				},
 			},
-			uncompressedPayload: `
-		{
-			"config_table": {
-				"plugins": [
-					{
-						"id": "759c0d3a-bc3d-4ccc-8d4d-f92de95c1f1a",
-						"name": "plugin_1",
-						"config": {
-							"plugin_field_1": "",
-							"plugin_field_2": "foo"
+			uncompressedPayload: `{
+				"config_table": {
+					"plugins": [
+						{
+							"id": "759c0d3a-bc3d-4ccc-8d4d-f92de95c1f1a",
+							"name": "plugin_1",
+							"config": {
+								"plugin_field_1": "",
+								"plugin_field_2": "foo"
+							}
 						}
-					}
-				]
-			}
-		}
-		`,
+					]
+				}
+			}`,
 			dataPlaneVersion: "3.0.0",
-			expectedPayload: `
-		{
-			"config_table": {
-				"plugins": [
-					{
-						"id": "759c0d3a-bc3d-4ccc-8d4d-f92de95c1f1a",
-						"name": "plugin_1",
-						"config": {
-							"plugin_field_2": "foo"
+			expectedPayload: `{
+				"config_table": {
+					"plugins": [
+						{
+							"id": "759c0d3a-bc3d-4ccc-8d4d-f92de95c1f1a",
+							"name": "plugin_1",
+							"config": {
+								"plugin_field_2": "foo"
+							}
 						}
-					}
-				]
-			}
-		}
-		`,
+					]
+				}
+			}`,
 			expectedChanges: TrackedChanges{
 				ChangeDetails: []ChangeDetail{
 					{
@@ -5729,38 +5717,34 @@ func TestVersionCompatibility_ProcessConfigTableUpdates(t *testing.T) {
 					},
 				},
 			},
-			uncompressedPayload: `
-		{
-			"config_table": {
-				"plugins": [
-					{
-						"id": "759c0d3a-bc3d-4ccc-8d4d-f92de95c1f1a",
-						"name": "plugin_1",
-						"config": {
-							"plugin_field_1": null,
-							"plugin_field_2": "foo"
+			uncompressedPayload: `{
+				"config_table": {
+					"plugins": [
+						{
+							"id": "759c0d3a-bc3d-4ccc-8d4d-f92de95c1f1a",
+							"name": "plugin_1",
+							"config": {
+								"plugin_field_1": null,
+								"plugin_field_2": "foo"
+							}
 						}
-					}
-				]
-			}
-		}
-		`,
+					]
+				}
+			}`,
 			dataPlaneVersion: "3.0.0",
-			expectedPayload: `
-		{
-			"config_table": {
-				"plugins": [
-					{
-						"id": "759c0d3a-bc3d-4ccc-8d4d-f92de95c1f1a",
-						"name": "plugin_1",
-						"config": {
-							"plugin_field_2": "foo"
+			expectedPayload: `{
+				"config_table": {
+					"plugins": [
+						{
+							"id": "759c0d3a-bc3d-4ccc-8d4d-f92de95c1f1a",
+							"name": "plugin_1",
+							"config": {
+								"plugin_field_2": "foo"
+							}
 						}
-					}
-				]
-			}
-		}
-		`,
+					]
+				}
+			}`,
 			expectedChanges: TrackedChanges{
 				ChangeDetails: []ChangeDetail{
 					{
@@ -5810,35 +5794,31 @@ func TestVersionCompatibility_ProcessConfigTableUpdates(t *testing.T) {
 					},
 				},
 			},
-			uncompressedPayload: `
-		{
-			"config_table": {
-				"plugins": [
-					{
-						"id": "759c0d3a-bc3d-4ccc-8d4d-f92de95c1f1a",
-						"name": "plugin_1",
-						"config": {
-							"plugin_field_1": []
+			uncompressedPayload: `{
+				"config_table": {
+					"plugins": [
+						{
+							"id": "759c0d3a-bc3d-4ccc-8d4d-f92de95c1f1a",
+							"name": "plugin_1",
+							"config": {
+								"plugin_field_1": []
+							}
 						}
-					}
-				]
-			}
-		}
-		`,
+					]
+				}
+			}`,
 			dataPlaneVersion: "3.0.0",
-			expectedPayload: `
-		{
-			"config_table": {
-				"plugins": [
-					{
-						"id": "759c0d3a-bc3d-4ccc-8d4d-f92de95c1f1a",
-						"name": "plugin_1",
-						"config": {}
-					}
-				]
-			}
-		}
-		`,
+			expectedPayload: `{
+				"config_table": {
+					"plugins": [
+						{
+							"id": "759c0d3a-bc3d-4ccc-8d4d-f92de95c1f1a",
+							"name": "plugin_1",
+							"config": {}
+						}
+					]
+				}
+			}`,
 			expectedChanges: TrackedChanges{
 				ChangeDetails: []ChangeDetail{
 					{

--- a/internal/server/kong/ws/config/version_compatibility_test.go
+++ b/internal/server/kong/ws/config/version_compatibility_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"github.com/tidwall/gjson"
 	"strings"
 	"testing"
 
@@ -5452,7 +5453,7 @@ func TestVersionCompatibility_ProcessConfigTableUpdates(t *testing.T) {
 			}`,
 		},
 		{
-			name: "updates conditionally ignores empty arrays",
+			name: "field updates conditionally ignore empty arrays",
 			configTableUpdates: map[string][]ConfigTableUpdates{
 				">= 3.0.0": {
 					{
@@ -5529,7 +5530,7 @@ func TestVersionCompatibility_ProcessConfigTableUpdates(t *testing.T) {
 			},
 		},
 		{
-			name: "updates conditionally ignores empty objects",
+			name: "field updates conditionally ignore empty objects",
 			configTableUpdates: map[string][]ConfigTableUpdates{
 				">= 3.0.0": {
 					{
@@ -5606,7 +5607,7 @@ func TestVersionCompatibility_ProcessConfigTableUpdates(t *testing.T) {
 			},
 		},
 		{
-			name: "updates conditionally ignores empty strings",
+			name: "field updates conditionally ignore empty strings",
 			configTableUpdates: map[string][]ConfigTableUpdates{
 				">= 3.0.0": {
 					{
@@ -5683,7 +5684,7 @@ func TestVersionCompatibility_ProcessConfigTableUpdates(t *testing.T) {
 			},
 		},
 		{
-			name: "updates conditionally ignores nil values",
+			name: "field updates conditionally ignore nil values",
 			configTableUpdates: map[string][]ConfigTableUpdates{
 				">= 3.0.0": {
 					{
@@ -5760,7 +5761,7 @@ func TestVersionCompatibility_ProcessConfigTableUpdates(t *testing.T) {
 			},
 		},
 		{
-			name: "does not create new fields when ignoring empty array values",
+			name: "field updates do not create new fields when ignoring empty array values",
 			configTableUpdates: map[string][]ConfigTableUpdates{
 				">= 3.0.0": {
 					{
@@ -5789,6 +5790,11 @@ func TestVersionCompatibility_ProcessConfigTableUpdates(t *testing.T) {
 						Type: Plugin,
 						RemoveFields: []string{
 							"plugin_field_1",
+						},
+						DisableChangeTracking: func(rawJSON string) bool {
+							// do not emit change if functions is set to default value (empty array)
+							plugin := gjson.Parse(rawJSON)
+							return len(plugin.Get("config.plugin_field_1").Array()) == 0
 						},
 						ChangeID: "T102",
 					},
@@ -5819,19 +5825,7 @@ func TestVersionCompatibility_ProcessConfigTableUpdates(t *testing.T) {
 					]
 				}
 			}`,
-			expectedChanges: TrackedChanges{
-				ChangeDetails: []ChangeDetail{
-					{
-						ID: "T102",
-						Resources: []ResourceInfo{
-							{
-								Type: "plugin",
-								ID:   "759c0d3a-bc3d-4ccc-8d4d-f92de95c1f1a",
-							},
-						},
-					},
-				},
-			},
+			expectedChanges: TrackedChanges{},
 		},
 	}
 

--- a/internal/server/kong/ws/config/version_compatibility_test.go
+++ b/internal/server/kong/ws/config/version_compatibility_test.go
@@ -2,13 +2,13 @@ package config
 
 import (
 	"fmt"
-	"github.com/tidwall/gjson"
 	"strings"
 	"testing"
 
 	"github.com/kong/koko/internal/log"
 	"github.com/kong/koko/internal/versioning"
 	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 	"go.uber.org/zap"
 )
@@ -5465,9 +5465,9 @@ func TestVersionCompatibility_ProcessConfigTableUpdates(t *testing.T) {
 								Condition: "plugin_field_1",
 								Updates: []ConfigTableFieldUpdate{
 									{
-										Field:          "plugin_field_2",
-										ValueFromField: "plugin_field_1",
-										IgnoreEmpty:    true,
+										Field:            "plugin_field_2",
+										ValueFromField:   "plugin_field_1",
+										FieldMustBeEmpty: true,
 									},
 									{
 										Field: "plugin_field_1",
@@ -5542,9 +5542,9 @@ func TestVersionCompatibility_ProcessConfigTableUpdates(t *testing.T) {
 								Condition: "plugin_field_1",
 								Updates: []ConfigTableFieldUpdate{
 									{
-										Field:          "plugin_field_2",
-										ValueFromField: "plugin_field_1",
-										IgnoreEmpty:    true,
+										Field:            "plugin_field_2",
+										ValueFromField:   "plugin_field_1",
+										FieldMustBeEmpty: true,
 									},
 									{
 										Field: "plugin_field_1",
@@ -5619,9 +5619,9 @@ func TestVersionCompatibility_ProcessConfigTableUpdates(t *testing.T) {
 								Condition: "plugin_field_1",
 								Updates: []ConfigTableFieldUpdate{
 									{
-										Field:          "plugin_field_2",
-										ValueFromField: "plugin_field_1",
-										IgnoreEmpty:    true,
+										Field:            "plugin_field_2",
+										ValueFromField:   "plugin_field_1",
+										FieldMustBeEmpty: true,
 									},
 									{
 										Field: "plugin_field_1",
@@ -5696,9 +5696,9 @@ func TestVersionCompatibility_ProcessConfigTableUpdates(t *testing.T) {
 								Condition: "plugin_field_1",
 								Updates: []ConfigTableFieldUpdate{
 									{
-										Field:          "plugin_field_2",
-										ValueFromField: "plugin_field_1",
-										IgnoreEmpty:    true,
+										Field:            "plugin_field_2",
+										ValueFromField:   "plugin_field_1",
+										FieldMustBeEmpty: true,
 									},
 									{
 										Field: "plugin_field_1",
@@ -5773,9 +5773,9 @@ func TestVersionCompatibility_ProcessConfigTableUpdates(t *testing.T) {
 								Condition: "plugin_field_1",
 								Updates: []ConfigTableFieldUpdate{
 									{
-										Field:          "plugin_field_2",
-										ValueFromField: "plugin_field_1",
-										IgnoreEmpty:    true,
+										Field:            "plugin_field_2",
+										ValueFromField:   "plugin_field_1",
+										FieldMustBeEmpty: true,
 									},
 									{
 										Field: "plugin_field_1",
@@ -5840,9 +5840,9 @@ func TestVersionCompatibility_ProcessConfigTableUpdates(t *testing.T) {
 								Condition: "plugin_field_1",
 								Updates: []ConfigTableFieldUpdate{
 									{
-										Field:          "plugin_field_2",
-										ValueFromField: "plugin_field_1",
-										IgnoreEmpty:    true,
+										Field:            "plugin_field_2",
+										ValueFromField:   "plugin_field_1",
+										FieldMustBeEmpty: true,
 									},
 									{
 										Field: "plugin_field_1",
@@ -5913,9 +5913,9 @@ func TestVersionCompatibility_ProcessConfigTableUpdates(t *testing.T) {
 								Condition: "plugin_field_1",
 								Updates: []ConfigTableFieldUpdate{
 									{
-										Field:          "plugin_field_2",
-										ValueFromField: "plugin_field_1",
-										IgnoreEmpty:    true,
+										Field:            "plugin_field_2",
+										ValueFromField:   "plugin_field_1",
+										FieldMustBeEmpty: true,
 									},
 									{
 										Field: "plugin_field_1",
@@ -5986,9 +5986,9 @@ func TestVersionCompatibility_ProcessConfigTableUpdates(t *testing.T) {
 								Condition: "plugin_field_1",
 								Updates: []ConfigTableFieldUpdate{
 									{
-										Field:          "plugin_field_2",
-										ValueFromField: "plugin_field_1",
-										IgnoreEmpty:    true,
+										Field:            "plugin_field_2",
+										ValueFromField:   "plugin_field_1",
+										FieldMustBeEmpty: true,
 									},
 									{
 										Field: "plugin_field_1",
@@ -6059,9 +6059,9 @@ func TestVersionCompatibility_ProcessConfigTableUpdates(t *testing.T) {
 								Condition: "plugin_field_1",
 								Updates: []ConfigTableFieldUpdate{
 									{
-										Field:          "plugin_field_2",
-										ValueFromField: "plugin_field_1",
-										IgnoreEmpty:    true,
+										Field:            "plugin_field_2",
+										ValueFromField:   "plugin_field_1",
+										FieldMustBeEmpty: true,
 									},
 									{
 										Field: "plugin_field_1",
@@ -6132,9 +6132,9 @@ func TestVersionCompatibility_ProcessConfigTableUpdates(t *testing.T) {
 								Condition: "plugin_field_1",
 								Updates: []ConfigTableFieldUpdate{
 									{
-										Field:          "plugin_field_2",
-										ValueFromField: "plugin_field_1",
-										IgnoreEmpty:    true,
+										Field:            "plugin_field_2",
+										ValueFromField:   "plugin_field_1",
+										FieldMustBeEmpty: true,
 									},
 									{
 										Field: "plugin_field_1",

--- a/internal/server/kong/ws/config/version_compatibility_test.go
+++ b/internal/server/kong/ws/config/version_compatibility_test.go
@@ -5554,14 +5554,6 @@ func TestVersionCompatibility_ProcessConfigTableUpdates(t *testing.T) {
 						},
 						ChangeID: "T101",
 					},
-					{
-						Name: "plugin_1",
-						Type: Plugin,
-						RemoveFields: []string{
-							"plugin_field_1",
-						},
-						ChangeID: "T102",
-					},
 				},
 			},
 			uncompressedPayload: `{
@@ -5595,7 +5587,7 @@ func TestVersionCompatibility_ProcessConfigTableUpdates(t *testing.T) {
 			expectedChanges: TrackedChanges{
 				ChangeDetails: []ChangeDetail{
 					{
-						ID: "T102",
+						ID: "T101",
 						Resources: []ResourceInfo{
 							{
 								Type: "plugin",
@@ -5631,14 +5623,6 @@ func TestVersionCompatibility_ProcessConfigTableUpdates(t *testing.T) {
 						},
 						ChangeID: "T101",
 					},
-					{
-						Name: "plugin_1",
-						Type: Plugin,
-						RemoveFields: []string{
-							"plugin_field_1",
-						},
-						ChangeID: "T102",
-					},
 				},
 			},
 			uncompressedPayload: `{
@@ -5672,7 +5656,7 @@ func TestVersionCompatibility_ProcessConfigTableUpdates(t *testing.T) {
 			expectedChanges: TrackedChanges{
 				ChangeDetails: []ChangeDetail{
 					{
-						ID: "T102",
+						ID: "T101",
 						Resources: []ResourceInfo{
 							{
 								Type: "plugin",
@@ -5708,14 +5692,6 @@ func TestVersionCompatibility_ProcessConfigTableUpdates(t *testing.T) {
 						},
 						ChangeID: "T101",
 					},
-					{
-						Name: "plugin_1",
-						Type: Plugin,
-						RemoveFields: []string{
-							"plugin_field_1",
-						},
-						ChangeID: "T102",
-					},
 				},
 			},
 			uncompressedPayload: `{
@@ -5749,7 +5725,7 @@ func TestVersionCompatibility_ProcessConfigTableUpdates(t *testing.T) {
 			expectedChanges: TrackedChanges{
 				ChangeDetails: []ChangeDetail{
 					{
-						ID: "T102",
+						ID: "T101",
 						Resources: []ResourceInfo{
 							{
 								Type: "plugin",
@@ -5785,14 +5761,6 @@ func TestVersionCompatibility_ProcessConfigTableUpdates(t *testing.T) {
 						},
 						ChangeID: "T101",
 					},
-					{
-						Name: "plugin_1",
-						Type: Plugin,
-						RemoveFields: []string{
-							"plugin_field_1",
-						},
-						ChangeID: "T102",
-					},
 				},
 			},
 			uncompressedPayload: `{
@@ -5826,7 +5794,7 @@ func TestVersionCompatibility_ProcessConfigTableUpdates(t *testing.T) {
 			expectedChanges: TrackedChanges{
 				ChangeDetails: []ChangeDetail{
 					{
-						ID: "T102",
+						ID: "T101",
 						Resources: []ResourceInfo{
 							{
 								Type: "plugin",
@@ -5862,14 +5830,6 @@ func TestVersionCompatibility_ProcessConfigTableUpdates(t *testing.T) {
 						},
 						ChangeID: "T101",
 					},
-					{
-						Name: "plugin_1",
-						Type: Plugin,
-						RemoveFields: []string{
-							"plugin_field_1",
-						},
-						ChangeID: "T102",
-					},
 				},
 			},
 			uncompressedPayload: `{
@@ -5903,7 +5863,7 @@ func TestVersionCompatibility_ProcessConfigTableUpdates(t *testing.T) {
 			expectedChanges: TrackedChanges{
 				ChangeDetails: []ChangeDetail{
 					{
-						ID: "T102",
+						ID: "T101",
 						Resources: []ResourceInfo{
 							{
 								Type: "plugin",

--- a/internal/server/kong/ws/config/version_compatibility_test.go
+++ b/internal/server/kong/ws/config/version_compatibility_test.go
@@ -5827,6 +5827,362 @@ func TestVersionCompatibility_ProcessConfigTableUpdates(t *testing.T) {
 			}`,
 			expectedChanges: TrackedChanges{},
 		},
+		{
+			name: "field updates conditionally ignore empty arrays",
+			configTableUpdates: map[string][]ConfigTableUpdates{
+				">= 3.0.0": {
+					{
+						Name: "plugin_1",
+						Type: CorePlugin,
+						FieldUpdates: []ConfigTableFieldCondition{
+							{
+								Field:     "plugin_field_1",
+								Condition: "plugin_field_1",
+								Updates: []ConfigTableFieldUpdate{
+									{
+										Field:          "plugin_field_2",
+										ValueFromField: "plugin_field_1",
+										IgnoreEmpty:    true,
+									},
+									{
+										Field: "plugin_field_1",
+									},
+								},
+							},
+						},
+						ChangeID: "T101",
+					},
+					{
+						Name: "plugin_1",
+						Type: CorePlugin,
+						RemoveFields: []string{
+							"plugin_field_1",
+						},
+						ChangeID: "T102",
+					},
+				},
+			},
+			uncompressedPayload: `{
+				"config_table": {
+					"plugins": [
+						{
+							"id": "759c0d3a-bc3d-4ccc-8d4d-f92de95c1f1a",
+							"name": "plugin_1",
+							"plugin_field_1": [],
+							"plugin_field_2": ["kong.log.err('Hello Koko!')"]
+						}
+					]
+				}
+			}`,
+			dataPlaneVersion: "3.0.0",
+			expectedPayload: `{
+				"config_table": {
+					"plugins": [
+						{
+							"id": "759c0d3a-bc3d-4ccc-8d4d-f92de95c1f1a",
+							"name": "plugin_1",
+							"plugin_field_2": ["kong.log.err('Hello Koko!')"]
+						}
+					]
+				}
+			}`,
+			expectedChanges: TrackedChanges{
+				ChangeDetails: []ChangeDetail{
+					{
+						ID: "T102",
+						Resources: []ResourceInfo{
+							{
+								Type: "plugin",
+								ID:   "759c0d3a-bc3d-4ccc-8d4d-f92de95c1f1a",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "field updates conditionally ignore empty objects",
+			configTableUpdates: map[string][]ConfigTableUpdates{
+				">= 3.0.0": {
+					{
+						Name: "plugin_1",
+						Type: CorePlugin,
+						FieldUpdates: []ConfigTableFieldCondition{
+							{
+								Field:     "plugin_field_1",
+								Condition: "plugin_field_1",
+								Updates: []ConfigTableFieldUpdate{
+									{
+										Field:          "plugin_field_2",
+										ValueFromField: "plugin_field_1",
+										IgnoreEmpty:    true,
+									},
+									{
+										Field: "plugin_field_1",
+									},
+								},
+							},
+						},
+						ChangeID: "T101",
+					},
+					{
+						Name: "plugin_1",
+						Type: CorePlugin,
+						RemoveFields: []string{
+							"plugin_field_1",
+						},
+						ChangeID: "T102",
+					},
+				},
+			},
+			uncompressedPayload: `{
+				"config_table": {
+					"plugins": [
+						{
+							"id": "759c0d3a-bc3d-4ccc-8d4d-f92de95c1f1a",
+							"name": "plugin_1",
+							"plugin_field_1": {},
+							"plugin_field_2": { "foo": "bar" }
+						}
+					]
+				}
+			}`,
+			dataPlaneVersion: "3.0.0",
+			expectedPayload: `{
+				"config_table": {
+					"plugins": [
+						{
+							"id": "759c0d3a-bc3d-4ccc-8d4d-f92de95c1f1a",
+							"name": "plugin_1",
+							"plugin_field_2": { "foo": "bar" }
+						}
+					]
+				}
+			}`,
+			expectedChanges: TrackedChanges{
+				ChangeDetails: []ChangeDetail{
+					{
+						ID: "T102",
+						Resources: []ResourceInfo{
+							{
+								Type: "plugin",
+								ID:   "759c0d3a-bc3d-4ccc-8d4d-f92de95c1f1a",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "field updates conditionally ignore empty strings",
+			configTableUpdates: map[string][]ConfigTableUpdates{
+				">= 3.0.0": {
+					{
+						Name: "plugin_1",
+						Type: CorePlugin,
+						FieldUpdates: []ConfigTableFieldCondition{
+							{
+								Field:     "plugin_field_1",
+								Condition: "plugin_field_1",
+								Updates: []ConfigTableFieldUpdate{
+									{
+										Field:          "plugin_field_2",
+										ValueFromField: "plugin_field_1",
+										IgnoreEmpty:    true,
+									},
+									{
+										Field: "plugin_field_1",
+									},
+								},
+							},
+						},
+						ChangeID: "T101",
+					},
+					{
+						Name: "plugin_1",
+						Type: CorePlugin,
+						RemoveFields: []string{
+							"plugin_field_1",
+						},
+						ChangeID: "T102",
+					},
+				},
+			},
+			uncompressedPayload: `{
+				"config_table": {
+					"plugins": [
+						{
+							"id": "759c0d3a-bc3d-4ccc-8d4d-f92de95c1f1a",
+							"name": "plugin_1",
+							"plugin_field_1": "",
+							"plugin_field_2": "foo"
+						}
+					]
+				}
+			}`,
+			dataPlaneVersion: "3.0.0",
+			expectedPayload: `{
+				"config_table": {
+					"plugins": [
+						{
+							"id": "759c0d3a-bc3d-4ccc-8d4d-f92de95c1f1a",
+							"name": "plugin_1",
+							"plugin_field_2": "foo"
+						}
+					]
+				}
+			}`,
+			expectedChanges: TrackedChanges{
+				ChangeDetails: []ChangeDetail{
+					{
+						ID: "T102",
+						Resources: []ResourceInfo{
+							{
+								Type: "plugin",
+								ID:   "759c0d3a-bc3d-4ccc-8d4d-f92de95c1f1a",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "field updates conditionally ignore nil values",
+			configTableUpdates: map[string][]ConfigTableUpdates{
+				">= 3.0.0": {
+					{
+						Name: "plugin_1",
+						Type: CorePlugin,
+						FieldUpdates: []ConfigTableFieldCondition{
+							{
+								Field:     "plugin_field_1",
+								Condition: "plugin_field_1",
+								Updates: []ConfigTableFieldUpdate{
+									{
+										Field:          "plugin_field_2",
+										ValueFromField: "plugin_field_1",
+										IgnoreEmpty:    true,
+									},
+									{
+										Field: "plugin_field_1",
+									},
+								},
+							},
+						},
+						ChangeID: "T101",
+					},
+					{
+						Name: "plugin_1",
+						Type: CorePlugin,
+						RemoveFields: []string{
+							"plugin_field_1",
+						},
+						ChangeID: "T102",
+					},
+				},
+			},
+			uncompressedPayload: `{
+				"config_table": {
+					"plugins": [
+						{
+							"id": "759c0d3a-bc3d-4ccc-8d4d-f92de95c1f1a",
+							"name": "plugin_1",
+							"plugin_field_1": null,
+							"plugin_field_2": "foo"
+						}
+					]
+				}
+			}`,
+			dataPlaneVersion: "3.0.0",
+			expectedPayload: `{
+				"config_table": {
+					"plugins": [
+						{
+							"id": "759c0d3a-bc3d-4ccc-8d4d-f92de95c1f1a",
+							"name": "plugin_1",
+							"plugin_field_2": "foo"
+						}
+					]
+				}
+			}`,
+			expectedChanges: TrackedChanges{
+				ChangeDetails: []ChangeDetail{
+					{
+						ID: "T102",
+						Resources: []ResourceInfo{
+							{
+								Type: "plugin",
+								ID:   "759c0d3a-bc3d-4ccc-8d4d-f92de95c1f1a",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "field updates do not create new fields when ignoring empty array values",
+			configTableUpdates: map[string][]ConfigTableUpdates{
+				">= 3.0.0": {
+					{
+						Name: "plugin_1",
+						Type: CorePlugin,
+						FieldUpdates: []ConfigTableFieldCondition{
+							{
+								Field:     "plugin_field_1",
+								Condition: "plugin_field_1",
+								Updates: []ConfigTableFieldUpdate{
+									{
+										Field:          "plugin_field_2",
+										ValueFromField: "plugin_field_1",
+										IgnoreEmpty:    true,
+									},
+									{
+										Field: "plugin_field_1",
+									},
+								},
+							},
+						},
+						ChangeID: "T101",
+					},
+					{
+						Name: "plugin_1",
+						Type: CorePlugin,
+						RemoveFields: []string{
+							"plugin_field_1",
+						},
+						DisableChangeTracking: func(rawJSON string) bool {
+							// do not emit change if functions is set to default value (empty array)
+							plugin := gjson.Parse(rawJSON)
+							return len(plugin.Get("config.plugin_field_1").Array()) == 0
+						},
+						ChangeID: "T102",
+					},
+				},
+			},
+			uncompressedPayload: `{
+				"config_table": {
+					"plugins": [
+						{
+							"id": "759c0d3a-bc3d-4ccc-8d4d-f92de95c1f1a",
+							"name": "plugin_1",
+							"plugin_field_1": []
+						}
+					]
+				}
+			}`,
+			dataPlaneVersion: "3.0.0",
+			expectedPayload: `{
+				"config_table": {
+					"plugins": [
+						{
+							"id": "759c0d3a-bc3d-4ccc-8d4d-f92de95c1f1a",
+							"name": "plugin_1"
+						}
+					]
+				}
+			}`,
+			expectedChanges: TrackedChanges{},
+		},
 	}
 
 	for _, test := range tests {

--- a/internal/test/e2e/plugins.go
+++ b/internal/test/e2e/plugins.go
@@ -235,11 +235,53 @@ var VersionCompatibilityOSSPluginConfigurationTests = []VersionCompatibilityPlug
 		ConfigureForRoute:   true,
 	},
 	{
+		Name: "post-function",
+		Config: `{
+			"access": [
+				"kong.log.err('Goodbye Koko!')"
+			],
+			"functions": []
+		}`,
+		FieldUpdateChecks: map[string][]FieldUpdateCheck{
+			">= 3.0.0": {
+				{
+					Field: "access",
+					Value: []string{
+						"kong.log.err('Goodbye Koko!')",
+					},
+				},
+			},
+		},
+		ConfigureForService: true,
+		ConfigureForRoute:   true,
+	},
+	{
 		Name: "pre-function",
 		Config: `{
 			"functions": [
 				"kong.log.err('Hello Koko!')"
 			]
+		}`,
+		FieldUpdateChecks: map[string][]FieldUpdateCheck{
+			">= 3.0.0": {
+				{
+					Field: "access",
+					Value: []string{
+						"kong.log.err('Hello Koko!')",
+					},
+				},
+			},
+		},
+		ConfigureForService: true,
+		ConfigureForRoute:   true,
+	},
+	{
+		Name: "pre-function",
+		Config: `{
+			"access": [
+				"kong.log.err('Hello Koko!')"
+			],
+			"functions": []
 		}`,
 		FieldUpdateChecks: map[string][]FieldUpdateCheck{
 			">= 3.0.0": {

--- a/internal/test/e2e/plugins.go
+++ b/internal/test/e2e/plugins.go
@@ -235,53 +235,11 @@ var VersionCompatibilityOSSPluginConfigurationTests = []VersionCompatibilityPlug
 		ConfigureForRoute:   true,
 	},
 	{
-		Name: "post-function",
-		Config: `{
-			"access": [
-				"kong.log.err('Goodbye Koko!')"
-			],
-			"functions": []
-		}`,
-		FieldUpdateChecks: map[string][]FieldUpdateCheck{
-			">= 3.0.0": {
-				{
-					Field: "access",
-					Value: []string{
-						"kong.log.err('Goodbye Koko!')",
-					},
-				},
-			},
-		},
-		ConfigureForService: true,
-		ConfigureForRoute:   true,
-	},
-	{
 		Name: "pre-function",
 		Config: `{
 			"functions": [
 				"kong.log.err('Hello Koko!')"
 			]
-		}`,
-		FieldUpdateChecks: map[string][]FieldUpdateCheck{
-			">= 3.0.0": {
-				{
-					Field: "access",
-					Value: []string{
-						"kong.log.err('Hello Koko!')",
-					},
-				},
-			},
-		},
-		ConfigureForService: true,
-		ConfigureForRoute:   true,
-	},
-	{
-		Name: "pre-function",
-		Config: `{
-			"access": [
-				"kong.log.err('Hello Koko!')"
-			],
-			"functions": []
 		}`,
 		FieldUpdateChecks: map[string][]FieldUpdateCheck{
 			">= 3.0.0": {

--- a/internal/test/e2e/version_compatibility_test.go
+++ b/internal/test/e2e/version_compatibility_test.go
@@ -282,6 +282,7 @@ func TestVersionCompatibility_EnsureTargetFieldsAreNotOverridden(t *testing.T) {
 	require.NoError(t, util.WaitForKong(t))
 	require.NoError(t, util.WaitForKongAdminAPI(t))
 
+	kongClient.RunWhenKong(t, ">=3.0.0")
 	kongAdmin, err := kongClient.NewClient(util.BasedKongAdminAPIAddr, nil)
 	require.NoError(t, err, "create go client for kong")
 	ctx := context.Background()
@@ -297,9 +298,6 @@ func TestVersionCompatibility_EnsureTargetFieldsAreNotOverridden(t *testing.T) {
 		{
 			Name: "pre-function",
 			Config: `{
-				"access": [
-					"kong.log.err('Hello Koko!')"
-				],
 				"functions": []
 			}`,
 			FieldUpdateChecks: map[string][]FieldUpdateCheck{

--- a/internal/test/e2e/version_compatibility_test.go
+++ b/internal/test/e2e/version_compatibility_test.go
@@ -226,7 +226,6 @@ func TestVersionCompatibility_PluginFieldUpdates(t *testing.T) {
 		require.NoError(t, err)
 		res := admin.POST("/v1/plugins").WithBytes(pluginBytes).Expect()
 		res.Status(http.StatusCreated)
-		require.Equal(t, http.StatusCreated, res.Raw().StatusCode)
 	}
 
 	// fetch list of plugins from the DP
@@ -301,9 +300,7 @@ func TestVersionCompatibility_EnsureTargetFieldsAreNotOverridden(t *testing.T) {
 				"access": [
 					"kong.log.err('Hello Koko!')"
 				],
-				"functions": [
-					"kong.log.err('Should not overwrite')"
-				]
+				"functions": []
 			}`,
 			FieldUpdateChecks: map[string][]FieldUpdateCheck{
 				">= 3.0.0": {

--- a/internal/test/e2e/version_compatibility_test.go
+++ b/internal/test/e2e/version_compatibility_test.go
@@ -273,6 +273,152 @@ func TestVersionCompatibility_PluginFieldUpdates(t *testing.T) {
 	}
 }
 
+func TestVersionCompatibility_EnsureTargetFieldsAreNotOverridden(t *testing.T) {
+	cleanup := run.Koko(t)
+	defer cleanup()
+
+	dpCleanup := run.KongDP(kong.GetKongConfForShared())
+	defer dpCleanup()
+	require.NoError(t, util.WaitForKong(t))
+	require.NoError(t, util.WaitForKongAdminAPI(t))
+
+	kongAdmin, err := kongClient.NewClient(util.BasedKongAdminAPIAddr, nil)
+	require.NoError(t, err, "create go client for kong")
+	ctx := context.Background()
+	info, err := kongAdmin.Root(ctx)
+	require.NoError(t, err, "fetching Kong Gateway info")
+
+	dataPlaneVersion, err := versioning.NewVersion(kongClient.VersionFromInfo(info))
+	require.NoError(t, err)
+
+	admin := httpexpect.New(t, "http://localhost:3000")
+
+	pluginTests := []VersionCompatibilityPlugins{
+		{
+			Name: "pre-function",
+			Config: `{
+				"access": [
+					"kong.log.err('Hello Koko!')"
+				],
+				"functions": []
+			}`,
+			FieldUpdateChecks: map[string][]FieldUpdateCheck{
+				">= 3.0.0": {
+					{
+						Field: "access",
+						Value: []string{
+							"kong.log.err('Hello Koko!')",
+						},
+					},
+				},
+			},
+			ConfigureForService: true,
+			ConfigureForRoute:   true,
+		},
+		{
+			Name: "post-function",
+			Config: `{
+				"access": [
+					"kong.log.err('Goodbye Koko!')"
+				],
+				"functions": []
+			}`,
+			FieldUpdateChecks: map[string][]FieldUpdateCheck{
+				">= 3.0.0": {
+					{
+						Field: "access",
+						Value: []string{
+							"kong.log.err('Goodbye Koko!')",
+						},
+					},
+				},
+			},
+			ConfigureForService: true,
+			ConfigureForRoute:   true,
+		},
+	}
+
+	expectedPluginsMap := make(map[string]VersionCompatibilityPlugins, 0)
+	for _, plugin := range pluginTests {
+		if plugin.FieldUpdateChecks == nil {
+			continue
+		}
+
+		if len(plugin.VersionRange) > 0 {
+			version := versioning.MustNewRange(plugin.VersionRange)
+			if !version(dataPlaneVersion) {
+				continue
+			}
+		}
+		expectedPluginsMap[plugin.Name] = plugin
+	}
+
+	// create plugins
+	for _, plugin := range expectedPluginsMap {
+		var config structpb.Struct
+		if len(plugin.Config) > 0 {
+			require.NoError(t, json.ProtoJSONUnmarshal([]byte(plugin.Config), &config))
+		}
+
+		p := &v1.Plugin{
+			Id:        uuid.NewString(),
+			Name:      plugin.Name,
+			Config:    &config,
+			Enabled:   wrapperspb.Bool(true),
+			Protocols: []string{"http", "https"},
+		}
+
+		pluginBytes, err := json.ProtoJSONMarshal(p)
+		require.NoError(t, err)
+		res := admin.POST("/v1/plugins").WithBytes(pluginBytes).Expect()
+		res.Status(http.StatusCreated)
+	}
+
+	// fetch list of plugins from the DP
+	dataPlanePlugins := []*kongClient.Plugin{}
+	util.WaitFunc(t, func() error {
+		dataPlanePlugins, err = kongAdmin.Plugins.ListAll(ctx)
+		if err != nil {
+			t.Log("fetch plugin failed", err)
+		}
+		if len(dataPlanePlugins) == 0 {
+			return errors.New("plugins len was 0")
+		}
+		return err
+	})
+
+	require.Equal(t, len(expectedPluginsMap), len(dataPlanePlugins), "plugins configured count does not match")
+	dpPluginsMap := make(map[string]string, 0)
+	for _, dpPlugin := range dataPlanePlugins {
+		b, err := json.ProtoJSONMarshal(dpPlugin.Config)
+		require.NoError(t, err)
+		dpPluginsMap[*dpPlugin.Name] = string(b)
+	}
+
+	for name, expectedPlugin := range expectedPluginsMap {
+		t.Run(fmt.Sprintf("%s successfully updates fields", name), func(t *testing.T) {
+			require.Contains(t, dpPluginsMap, name, "plugin not present in the DP")
+			for rawVersion, updates := range expectedPlugin.FieldUpdateChecks {
+				parsedVersion := versioning.MustNewRange(rawVersion)
+				if parsedVersion(dataPlaneVersion) {
+					for _, update := range updates {
+						want := update.Value
+						have := gjson.Get(dpPluginsMap[name], update.Field)
+						switch want.(type) {
+						case string:
+							require.Equal(t, want, have.String())
+						case []string:
+							require.ElementsMatch(t, want, have.Value())
+						default:
+							require.Equal(t, want, have.Value())
+						}
+					}
+				}
+			}
+		})
+	}
+}
+
 func TestVersionCompatibilitySyslogFacilityField(t *testing.T) {
 	cleanup := run.Koko(t)
 	defer cleanup()

--- a/internal/test/e2e/version_compatibility_test.go
+++ b/internal/test/e2e/version_compatibility_test.go
@@ -226,6 +226,7 @@ func TestVersionCompatibility_PluginFieldUpdates(t *testing.T) {
 		require.NoError(t, err)
 		res := admin.POST("/v1/plugins").WithBytes(pluginBytes).Expect()
 		res.Status(http.StatusCreated)
+		require.Equal(t, http.StatusCreated, res.Raw().StatusCode)
 	}
 
 	// fetch list of plugins from the DP
@@ -300,7 +301,9 @@ func TestVersionCompatibility_EnsureTargetFieldsAreNotOverridden(t *testing.T) {
 				"access": [
 					"kong.log.err('Hello Koko!')"
 				],
-				"functions": []
+				"functions": [
+					"kong.log.err('Should not overwrite')"
+				]
 			}`,
 			FieldUpdateChecks: map[string][]FieldUpdateCheck{
 				">= 3.0.0": {

--- a/internal/test/e2e/version_compatibility_test.go
+++ b/internal/test/e2e/version_compatibility_test.go
@@ -298,6 +298,9 @@ func TestVersionCompatibility_EnsureTargetFieldsAreNotOverridden(t *testing.T) {
 		{
 			Name: "pre-function",
 			Config: `{
+				"access": [
+					"kong.log.err('Hello Koko!')"
+				],
 				"functions": []
 			}`,
 			FieldUpdateChecks: map[string][]FieldUpdateCheck{


### PR DESCRIPTION
Fixes a bug where if either a pre-function or post-function plugin config contained config.access
and was < v3.0.0 with a downstream dp > v3.0.0, the access field is overwritten with the empty array
and is rejected by the dp.

Generally: updates the processing performed on plugin configs during version compatibility updates.
Previously, an empty array value would overwrite an existing target array value when performing the update.
This is an edge case as the target value being overwritten is on a field that does not exist
for the control-plane version but does exist for the data-plane config.

More concretely:
* Version < v3.0.0
  * creates a default value functions: [] when functions is undefined
  * access field does not exist (but can be defined by user)
* Version > v3.0.0
  * Creates an access field and copies the value contained in functions
  * Removes functions field from config
* Edge-case: config version < 3.0.0 contains access: ["some-value"] and functions is undefined
  * Under-the-hood, functions is set to default value functions: []
  * Since functions field exists, version compat overwrites existing access with empty value
  * Downstream > 3.0.0 dp rejects config validation as access must not be empty
