### PR TITLE
fix: CA certs validation let certs with CA=False pass

### DIFF
--- a/internal/resource/ca_certificate.go
+++ b/internal/resource/ca_certificate.go
@@ -97,8 +97,8 @@ func (r CACertificate) Validate(ctx context.Context) error {
 			},
 		}
 	}
-	if !cert.BasicConstraintsValid {
-		errStr := `certificate does not appear to be a CA because` +
+	if !cert.BasicConstraintsValid || !cert.IsCA {
+		errStr := `certificate does not appear to be a CA because ` +
 			`it is missing the "CA" basic constraint`
 		return validation.Error{
 			Errs: []*v1.ErrorDetail{

--- a/internal/resource/ca_certificate_test.go
+++ b/internal/resource/ca_certificate_test.go
@@ -76,7 +76,7 @@ p0TGlNicxb2nnhRuh1U63VkBhl3k17vClDiwqHYwe7fPzlmj6kZMaXnpK6rd4kg7
 -----END CERTIFICATE-----
 `
 
-	invalidCert = `
+	invalidCertOne = `
 -----BEGIN CERTIFICATE-----
 MIIE4DCCAsigAwIBAgIBATANBgkqhkiG9w0BAQsFADAaMRgwFgYDVQQKDA9rb25n
 X2NsdXN0ZXJpbmcwHhcNMjIwMzA5MDk0MDQ0WhcNMzIwMjI1MDk0MDQ0WjAaMRgw
@@ -105,6 +105,38 @@ AM+NHourg1pQkSdqfaPMlxXHiHihIMDnUU+TA2buOrJ+vB84i5j0u06qSj20+zHe
 XAgC4eDa8hIbDB4npueEAwmOTz6/vm+2yBgQsknrcaKyUK6dBwhq7mJqln5sHd1j
 kE8xEEqIS+ND090MMgPWS+lnhuLq2ztWwtR8xmZssembJnVCgejsDot5egFDAcYw
 R7aUSg==
+-----END CERTIFICATE-----
+`
+
+	invalidCertTwo = `
+-----BEGIN CERTIFICATE-----
+MIIE8jCCAtqgAwIBAgICEAQwDQYJKoZIhvcNAQELBQAwgYExCzAJBgNVBAYTAkFV
+MREwDwYDVQQIDAhWaWN0b3JpYTESMBAGA1UEBwwJTWVsYm91cm5lMREwDwYDVQQK
+DAhmb01NIEx0ZDEbMBkGA1UECwwSZm9NTSBSU0EgQ2xpZW50IENBMRswGQYDVQQD
+DBJmb01NIFJTQSBDbGllbnQgQ0EwHhcNMjIwMzMwMDY0NjU3WhcNMjMwNDA5MDY0
+NjU3WjAWMRQwEgYDVQQDDAtkZW1vQGxpLmxhbjCCASIwDQYJKoZIhvcNAQEBBQAD
+ggEPADCCAQoCggEBAMusWI4QGXU+NH8Iar8qSF5XU08wK7pnKavIa1z2vCSEMtRE
+UehLSJuWjn5rDut1HLVcoAcV+kPRdKBNZP56XnQFZHV6p8wBMM6xor8K9B7vknBa
+fCz2dX1+rsu3BrBO6QTOaegRdXfvHx9Qk0VHYHvRaM+o47WY7A1dts9yLVpABGCI
+1ScC9K0hoCl0Th+jkNHrVPy/1iM623Ws5TCqnr5nnQkKBuDzO/vXc4w7uijCjrXL
+TailK+9ol1p1ZCpELSMsrwn9xrzWrNFraNnj9l8z+YletQFMinaBQgMVIfBcEP4x
+YS/mVLaJmyZK2IHYrE++mfokyUt8RUXQ9HTbEbMCAwEAAaOB3TCB2jAJBgNVHRME
+AjAAMBEGCWCGSAGG+EIBAQQEAwIFoDAzBglghkgBhvhCAQ0EJhYkT3BlblNTTCBH
+ZW5lcmF0ZWQgQ2xpZW50IENlcnRpZmljYXRlMB0GA1UdDgQWBBQeax7vnvtoFvr2
+9QlRw2RQdVPjKzAfBgNVHSMEGDAWgBR39H6D/oOnso24wy0ldGFWh4CFFDAOBgNV
+HQ8BAf8EBAMCBeAwHQYDVR0lBBYwFAYIKwYBBQUHAwIGCCsGAQUFBwMEMBYGA1Ud
+EQQPMA2CC2RlbW9AbGkubGFuMA0GCSqGSIb3DQEBCwUAA4ICAQAK4//22q7CEruU
+mJPxuQI6yCK2klEA0DkGofChtk2swvEJD5lF23AlT5p4xF2GNxlV8IrtCQKd0bF8
+qvH7xc94s7sIAG+XOVSnoItLZFHf6FktBD07m5ktuP9RgcMUiPLDB74Q5Elm3uu3
+004LTpYGTQRE2PEuT2Q6SfmuO8+t9fzdgdmCcn1Js4XyvjhUnse/82K4PDw2gSnL
+2VSbNgJdXZPHH4bvdLuvtyIXJKLwjBNOSmGTyvLy5NTdxqSx9EMsorAR29ziHEbY
+wczSkxtVo9mLy532V52A4KvcG0/nQbg4GbzdGfSmdTwIZ5zOxDJZfyRIPK9npKlc
+g2WR3QJ5LYoN8CkeFcc/UPUZgzmQVWVdIWFqKP9WIPCcvDudQaiLPbzPdZXeWxmC
+wR9AkhNGUbIsGPwwp7EW8BVVGU6pMAabuaCoxCWctdtlP73LzitYSh8lTah61cyI
+ajjd5ATqkYHmqttvEjFL7pwqA0YytBuRNaMPluUCYzHNXswpdW4JtgYF7Cw22JTc
+046AnG2thgODeaqYFkoAK4LFQ+PnWsKqM8OGsth3VTlnNDH0NX5pKJ14Yvh0r2rA
+jhhv6SAtbw4k9ZJGp/Bsum58u5i/ShPy1NuML3cCjdb/u1/OkWaLhgo1J4L6a7/o
+oBjbFPiujznjahpW7JTZsiP0ZiCmJw==
 -----END CERTIFICATE-----
 `
 
@@ -199,11 +231,11 @@ func TestCACertificate_Validate(t *testing.T) {
 			},
 		},
 		{
-			name: "valid certificate, but invalid CA fails",
+			name: "valid certificate, but invalid basic constraint fails",
 			CACertificate: func() CACertificate {
 				cert := NewCACertificate()
 				_ = cert.ProcessDefaults(context.Background())
-				cert.CACertificate.Cert = invalidCert
+				cert.CACertificate.Cert = invalidCertOne
 				return cert
 			},
 			wantErr: true,
@@ -211,7 +243,25 @@ func TestCACertificate_Validate(t *testing.T) {
 				{
 					Type:  model.ErrorType_ERROR_TYPE_FIELD,
 					Field: "cert",
-					Messages: []string{`certificate does not appear to be a CA because` +
+					Messages: []string{`certificate does not appear to be a CA because ` +
+						`it is missing the "CA" basic constraint`},
+				},
+			},
+		},
+		{
+			name: "valid certificate, but invalid 'CA' basic constraint is false",
+			CACertificate: func() CACertificate {
+				cert := NewCACertificate()
+				_ = cert.ProcessDefaults(context.Background())
+				cert.CACertificate.Cert = invalidCertTwo
+				return cert
+			},
+			wantErr: true,
+			Errs: []*model.ErrorDetail{
+				{
+					Type:  model.ErrorType_ERROR_TYPE_FIELD,
+					Field: "cert",
+					Messages: []string{`certificate does not appear to be a CA because ` +
 						`it is missing the "CA" basic constraint`},
 				},
 			},

--- a/internal/server/admin/ca_certificate_test.go
+++ b/internal/server/admin/ca_certificate_test.go
@@ -250,7 +250,7 @@ func TestCACertificateCreate(t *testing.T) {
 			v1.ErrorType_ERROR_TYPE_FIELD.String())
 		errRes.Object().ValueEqual("field", "cert")
 		errRes.Object().ValueEqual("messages", []string{
-			`certificate does not appear to be a CA because` +
+			`certificate does not appear to be a CA because ` +
 				`it is missing the "CA" basic constraint`,
 		})
 	})

--- a/internal/test/seed/resource.go
+++ b/internal/test/seed/resource.go
@@ -28,13 +28,13 @@ var DefaultNewResourceFuncs = map[model.Type]NewResourceFunc{
 	resource.TypeCACertificate: func(_ Seeder, m proto.Message, _ int) error {
 		r := m.(*v1.CACertificate)
 		var err error
-		r.Cert, _, err = util.GenerateCertificate(defaultCertificateBits)
+		r.Cert, _, err = util.GenerateCertificate(defaultCertificateBits, true)
 		return err
 	},
 	resource.TypeCertificate: func(_ Seeder, m proto.Message, _ int) error {
 		r := m.(*v1.Certificate)
 		var err error
-		r.Cert, r.Key, err = util.GenerateCertificate(defaultCertificateBits)
+		r.Cert, r.Key, err = util.GenerateCertificate(defaultCertificateBits, false)
 		return err
 	},
 	resource.TypeConsumer: func(_ Seeder, m proto.Message, i int) error {

--- a/internal/test/util/util.go
+++ b/internal/test/util/util.go
@@ -134,7 +134,7 @@ func WaitForAdminAPI(t *testing.T) error {
 
 // GenerateCertificate creates a random certificate with the given
 // amount of bits, and returns the PEM encoded public & private keys.
-func GenerateCertificate(bits int) (publicKey string, privateKey string, err error) {
+func GenerateCertificate(bits int, isCA bool) (publicKey string, privateKey string, err error) {
 	caCert := &x509.Certificate{
 		SerialNumber:          big.NewInt(1),
 		Subject:               pkix.Name{Organization: []string{"Test"}},
@@ -142,6 +142,7 @@ func GenerateCertificate(bits int) (publicKey string, privateKey string, err err
 		NotAfter:              time.Now().Add(24 * time.Hour), //nolint:gomnd
 		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
 		BasicConstraintsValid: true,
+		IsCA:                  isCA,
 	}
 
 	pk, err := rsa.GenerateKey(rand.Reader, bits)


### PR DESCRIPTION
Right now the CA certs validation is only checking whether the cert's Basic Constraints attribute is valid or not, while it should also check whether the 'CA' basic constraint is set and fail if it's not.