### PR TITLE
tests: add e2e for secrets management

### DIFF
--- a/internal/test/e2e/vault_test.go
+++ b/internal/test/e2e/vault_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/google/uuid"
 	kongClient "github.com/kong/go-kong/kong"
 	v1 "github.com/kong/koko/internal/gen/grpc/kong/admin/model/v1"
+	"github.com/kong/koko/internal/json"
 	"github.com/kong/koko/internal/test/kong"
 	"github.com/kong/koko/internal/test/run"
 	"github.com/kong/koko/internal/test/util"
@@ -103,11 +104,17 @@ func TestSecretsManagementEnvVault(t *testing.T) {
 		Name:   "env",
 		Prefix: "my-env-vault",
 		Config: &v1.Vault_Config{
-			Prefix: "KONG_MY_SECRET_",
+			Config: &v1.Vault_Config_Env{
+				Env: &v1.Vault_EnvConfig{
+					Prefix: "KONG_MY_SECRET_",
+				},
+			},
 		},
 	}
 
-	c.POST("/v1/vaults").WithJSON(vault).Expect().Status(http.StatusCreated)
+	vaultBytes, err := json.ProtoJSONMarshal(vault)
+	require.NoError(t, err)
+	c.POST("/v1/vaults").WithBytes(vaultBytes).Expect().Status(http.StatusCreated)
 
 	// create service
 	service := &v1.Service{

--- a/internal/test/e2e/vault_test.go
+++ b/internal/test/e2e/vault_test.go
@@ -1,0 +1,218 @@
+//go:build integration
+
+package e2e
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/cenkalti/backoff/v4"
+	"github.com/gavv/httpexpect/v2"
+	"github.com/google/uuid"
+	kongClient "github.com/kong/go-kong/kong"
+	v1 "github.com/kong/koko/internal/gen/grpc/kong/admin/model/v1"
+	"github.com/kong/koko/internal/test/kong"
+	"github.com/kong/koko/internal/test/run"
+	"github.com/kong/koko/internal/test/util"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	goodCACertPEM = []byte(`-----BEGIN CERTIFICATE-----
+MIIE6DCCAtACCQCjgi452nKnUDANBgkqhkiG9w0BAQsFADA2MQswCQYDVQQGEwJV
+UzETMBEGA1UECAwKQ2FsaWZvcm5pYTESMBAGA1UEAwwJbG9jYWxob3N0MB4XDTIy
+MTAwNDE4NTEyOFoXDTMyMTAwMTE4NTEyOFowNjELMAkGA1UEBhMCVVMxEzARBgNV
+BAgMCkNhbGlmb3JuaWExEjAQBgNVBAMMCWxvY2FsaG9zdDCCAiIwDQYJKoZIhvcN
+AQEBBQADggIPADCCAgoCggIBALUwleXMo+CxQFvgtmJbWHO4k3YBJwzWqcr2xWn+
+vgeoLiKFDQC11F/nnWNKkPZyilLeJda5c9YEVaA9IW6/PZhxQ430RM53EJHoiIPB
+B9j7BHGzsvWYHEkjXvGQWeD3mR4TAkoCVTfPAjBji/SL+WvLpgPW5hKRVuedD8ja
+cTvkNfk6u2TwPYGgekh9+wS9zcEQs4OwsEiQxmi3Z8if1m1uD09tjqAHb0klPEzM
+64tPvlzJrIcH3Z5iF+B9qr91PCQJVYOCjGWlUgPULaqIoTVtY+AnaNnNcol0LM/i
+oq7uD0JbeyIFDFMDJVqZwDf/zowzLLlP8Hkok4M8JTefXvB0puQoxmGwOAhwlA0G
+KF5etrmhg+dOb+f3nWdgbyjPEytyOeMOOA/4Lb8dHRlf9JnEc4DJqwRVPM9BMeUu
+9ZlrSWvURRk8nUZfkjTstLqO2aeubfOvb+tDKUq5Ue2B+AFs0ETLy3bds8TU9syV
+5Kl+tIwek2TXzc7afvmeCDoRunAx5nVhmW8dpGhknOmJM0GxOi5s2tiu8/3T9XdH
+WcH/GMrocZrkhvzkZccSLYoo1jcDn9LwxHVr/BZ43NymjVa6T3QRTta4Kg5wWpfS
+yXi4gIW7VJM12CmNfSDEXqhF03+fjFzoWH+YfBK/9GgUMNjnXWIL9PgFFOBomwEL
+tv5zAgMBAAEwDQYJKoZIhvcNAQELBQADggIBAKH8eUGgH/OSS3mHB3Gqv1m2Ea04
+Cs03KNEt1weelcHIBWVnPp+jGcSIIfMBnDFAwgxtBKhwptJ9ZKXIzjh7YFxbOT01
+NU+KQ6tD+NFDf+SAUC4AWV9Cam63JIaCVNDoo5UjVMlssnng7NefM1q2+ucoP+gs
++bvUCTJcp3FZsq8aUI9Rka575HqRhl/8kyhcwICCgT5UHQJvCQYrInJ0Faem6dr0
+tHw+PZ1bo6qB7uxBjK9kyu7dK/vEKliUGM4/MXMDKIc5qXUs47wPLbjxvKsuDglK
+KftgUWNYRxx9Bf9ylbjd+ayo3+1Lb9cbvdZnh0UHN6677NvXlWNheCmeysLGQHtm
+5H6iIhZ75r6QuC7m6hBSJYtLU3fsQECrmaS/+xBGoSSZjacciO7b7qjQdWOfQREn
+7vc5eu0N+CJkp8t3SsyQP6v2Su3ILeTt2EWrmmE4K7SYlJe1HrUVj0AWUwzLa6+Z
++Dx16p3M0RBdFMGNNhLqvG3WRfE5c5md34Aq/C5ePjN7pQGmJhI6weowuX9wCrnh
+nJJJRfqyJvqgnVBZ6IawNcOyIofITZHlYVKuaDB1odzWCDNEvFftgJvH0MnO7OY9
+Pb9hILPoCy+91jQAVh6Z/ghIcZKHV+N6zV3uS3t5vCejhCNK8mUPSOwAeDf3Bq5r
+wQPXd0DdsYGmXVIh
+-----END CERTIFICATE-----`)
+
+	badCACertPEM = []byte(`-----BEGIN CERTIFICATE-----
+MIIDkzCCAnugAwIBAgIUYGc07pbHSjOBPreXh7OcNT2+sD4wDQYJKoZIhvcNAQEL
+BQAwWTELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAkNBMRUwEwYDVQQKDAxZb2xvNDIs
+IEluYy4xJjAkBgNVBAMMHVlvbG80MiBzZWxmLXNpZ25lZCB0ZXN0aW5nIENBMB4X
+DTIyMDMyOTE5NDczM1oXDTMyMDMyNjE5NDczM1owWTELMAkGA1UEBhMCVVMxCzAJ
+BgNVBAgMAkNBMRUwEwYDVQQKDAxZb2xvNDIsIEluYy4xJjAkBgNVBAMMHVlvbG80
+MiBzZWxmLXNpZ25lZCB0ZXN0aW5nIENBMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8A
+MIIBCgKCAQEAvnhTgdJALnuLKDA0ZUZRVMqcaaC+qvfJkiEFGYwX2ZJiFtzU65F/
+sB2L0ToFqY4tmMVlOmiSZFnRLDZecmQDbbNwc3wtNikmxIOzx4qR4kbRP8DDdyIf
+gaNmGCuaXTM5+FYy2iNBn6CeibIjqdErQlAbFLwQs5t3mLsjii2U4cyvfRtO+0RV
+HdJ6Np5LsVziN0c5gVIesIrrbxLcOjtXDzwd/w/j5NXqL/OwD5EBH2vqd3QKKX4t
+s83BLl2EsbUse47VAImavrwDhmV6S/p/NuJHqjJ6dIbXLYxNS7g26ijcrXxvNhiu
+YoZTykSgdI3BXMNAm1ahP/BtJPZpU7CVdQIDAQABo1MwUTAdBgNVHQ4EFgQUe1WZ
+fMfZQ9QIJIttwTmcrnl40ccwHwYDVR0jBBgwFoAUe1WZfMfZQ9QIJIttwTmcrnl4
+0ccwDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEAs4Z8VYbvEs93
+haTHdbbaKk0V6xAL/Q8I8GitK9E8cgf8C5rwwn+wU/Gf39dtMUlnW8uxyzRPx53u
+CAAcJAWkabT+xwrlrqjO68H3MgIAwgWA5yZC+qW7ECA8xYEK6DzEHIaOpagJdKcL
+IaZr/qTJlEQClvwDs4x/BpHRB5XbmJs86GqEB7XWAm+T2L8DluHAXvek+welF4Xo
+fQtLlNS/vqTDqPxkSbJhFv1L7/4gdwfAz51wH/iL7AG/ubFEtoGZPK9YCJ40yTWz
+8XrUoqUC+2WIZdtmo6dFFJcLfQg4ARJZjaK6lmxJun3iRMZjKJdQKm/NEKz4y9kA
+u8S6yNlu2Q==
+-----END CERTIFICATE-----`)
+)
+
+// This test makes sure secrets management works as expected end-to-end
+// by configuring:
+// - a Service and a Route to verify the overall flow works end-to-end
+// - a Certificate with secret references
+// - an SNI for localhost
+// - an {env} Vault using 'KONG_MY_SECRET_' as env variables prefix
+//
+// The needed secrets are injected in the testing DP using the
+// KONG_MY_SECRET_CERT and KONG_MY_SECRET_KEY env variables storing
+// cert/key signed with `goodCACertPEM`.
+//
+// After the configuration is synced in the DP, an HTTPS client is
+// created using the `goodCACertPEM` used to sign the
+// deployed certificate, and then a GET is performed to test the
+// proxy functionality, which should return a 200.
+func TestSecretsManagementEnvVault(t *testing.T) {
+	// ensure that Vaults can be synced to Kong gateway
+	cleanup := run.Koko(t)
+	defer cleanup()
+
+	c := httpexpect.New(t, "http://localhost:3000")
+
+	// create vault entity
+	vault := &v1.Vault{
+		Id:     uuid.NewString(),
+		Name:   "env",
+		Prefix: "my-env-vault",
+		Config: &v1.Vault_Config{
+			Prefix: "KONG_MY_SECRET_",
+		},
+	}
+
+	c.POST("/v1/vaults").WithJSON(vault).Expect().Status(http.StatusCreated)
+
+	// create service
+	service := &v1.Service{
+		Id:   uuid.NewString(),
+		Name: "foo",
+		Host: "mockbin.org",
+		Path: "/status/200",
+	}
+	c.POST("/v1/services").WithJSON(service).Expect().Status(http.StatusCreated)
+
+	// create route
+	route := &v1.Route{
+		Name:  "bar",
+		Paths: []string{"/r1"},
+		Service: &v1.Service{
+			Id: service.Id,
+		},
+	}
+	c.POST("/v1/routes").WithJSON(route).Expect().Status(http.StatusCreated)
+
+	// create certificate
+	certificate := &v1.Certificate{
+		Id:   uuid.NewString(),
+		Cert: "{vault://my-env-vault/cert}",
+		Key:  "{vault://my-env-vault/key}",
+	}
+	c.POST("/v1/certificates").WithJSON(certificate).Expect().Status(http.StatusCreated)
+
+	// create sni
+	sni := &v1.SNI{
+		Id:   uuid.NewString(),
+		Name: "localhost",
+		Certificate: &v1.Certificate{
+			Id: certificate.Id,
+		},
+	}
+	c.POST("/v1/snis").WithJSON(sni).Expect().Status(http.StatusCreated)
+
+	dpCleanup := run.KongDP(kong.GetKongConfForSharedWithSecrets())
+	defer dpCleanup()
+
+	require.NoError(t, util.WaitForKongAdminAPI(t))
+	kongClient.RunWhenKong(t, ">= 3.0.0")
+
+	expectedConfig := &v1.TestingConfig{
+		Vaults:       []*v1.Vault{vault},
+		Services:     []*v1.Service{service},
+		Routes:       []*v1.Route{route},
+		Certificates: []*v1.Certificate{certificate},
+		Snis:         []*v1.SNI{sni},
+	}
+	util.WaitFunc(t, func() error {
+		err := util.EnsureConfig(expectedConfig)
+		t.Log("configuration mismatch for vault", err)
+		return err
+	})
+
+	require.NoError(t, backoff.RetryNotify(func() error {
+		// build simple http client
+		client := &http.Client{}
+		// use simple http client with https should result
+		// in a failure due to missing certificate.
+		_, err := client.Get("https://localhost:8443/r1") //nolint:bodyclose
+		require.Error(t, err)
+
+		// use transport with wrong CA cert should result
+		// in a failure due to unknown authority.
+		badCACertPool := x509.NewCertPool()
+		badCACertPool.AppendCertsFromPEM(badCACertPEM)
+
+		client = &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{
+					RootCAs:    badCACertPool,
+					ClientAuth: tls.RequireAndVerifyClientCert,
+				},
+			},
+		}
+
+		_, err = client.Get("https://localhost:8443/r1") //nolint:bodyclose
+		require.Error(t, err)
+
+		// use transport with good CA cert should pass
+		// if referenced secrets are resolved correctly
+		// using the ENV vault.
+		goodCACertPool := x509.NewCertPool()
+		goodCACertPool.AppendCertsFromPEM(goodCACertPEM)
+
+		client = &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{
+					RootCAs:    goodCACertPool,
+					ClientAuth: tls.RequireAndVerifyClientCert,
+				},
+			},
+		}
+
+		resp, err := client.Get("https://localhost:8443/r1")
+		if err != nil {
+			return fmt.Errorf("unexpected response: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode == http.StatusOK {
+			return nil
+		}
+		return fmt.Errorf("unexpected code: %v", resp.StatusCode)
+	}, util.TestBackoff, nil))
+}

--- a/internal/test/kong/docker.go
+++ b/internal/test/kong/docker.go
@@ -37,6 +37,7 @@ var defaultEnvVars = map[string]string{
 //nolint:gomnd
 var defaultDockerPorts = map[int]int{
 	8000: 8000, // Kong DP HTTP proxy port (`KONG_PROXY_LISTEN`).
+	8443: 8443, // Kong DP HTTPS proxy port (`KONG_PROXY_LISTEN`).
 	8001: 8001, // Kong DP HTTP admin API port (`KONG_ADMIN_LISTEN`).
 }
 

--- a/internal/test/kong/run.go
+++ b/internal/test/kong/run.go
@@ -32,6 +32,64 @@ const (
 	fileClusterKey    = "/certs/cluster.key"
 )
 
+// Secrets used to test secrets management.
+const (
+	secretCert = `-----BEGIN CERTIFICATE-----
+MIIEczCCAlugAwIBAgIJAMw8/GAiHIFBMA0GCSqGSIb3DQEBCwUAMDYxCzAJBgNV
+BAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRIwEAYDVQQDDAlsb2NhbGhvc3Qw
+HhcNMjIxMDA0MTg1MjI5WhcNMjcxMDAzMTg1MjI5WjA2MQswCQYDVQQGEwJVUzET
+MBEGA1UECAwKQ2FsaWZvcm5pYTESMBAGA1UEAwwJbG9jYWxob3N0MIIBIjANBgkq
+hkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA3LUv6RauFfFn4a2BNSTE5oQNhASBh2Lk
+0Gd0tfPcmTzJbohFwyAGskYj0NBRxnRVZdLPeoZIQyYSaiPWyeDITnXyKk3Nh9Zk
+xQ03YsbZCk9jIsp78/ECdnYCCS4dpYGswu8b37dxUta+6AhEEte73ezrAhc+ZIy5
+2yjcix4P5+vfhBf0EzBT8D7z+wZjji3F/A969EqphFwPz3KudkTOR6d0bQEVbN3x
+cg4lcj49RzwS4sPbq6ub52QrKcx8s+d9bqC/nhHLn1HM/eef+cxROedcIWZs5RvG
+mk/H+K2lcKL33gIcXgzSeunobV+8xwwoYk4GZroXjavUkgelKKjQBQIDAQABo4GD
+MIGAMFAGA1UdIwRJMEehOqQ4MDYxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxp
+Zm9ybmlhMRIwEAYDVQQDDAlsb2NhbGhvc3SCCQCjgi452nKnUDAJBgNVHRMEAjAA
+MAsGA1UdDwQEAwIE8DAUBgNVHREEDTALgglsb2NhbGhvc3QwDQYJKoZIhvcNAQEL
+BQADggIBAJiKfxuh2g0fYcR7s6iiiOMhT1ZZoXhyDhoHUUMlyN9Lm549PBQHOX6V
+f/g+jqVawIrGLaQbTbPoq0XPTZohk4aYwSgU2Th3Ku8Q73FfO0MM1jjop3WCatNF
+VZj/GBc9uVunOV5aMcMIs2dFU2fwH4ZjOwnv7rJRldoW1Qlk3uWeIktbmv4yZKvu
+FWPuo3ks+7B+BniqKXuYkNcuhlE+iVr3kJ55qRgX1RxKo4CB3Tynkp7sikp4al7x
+jlHSM9YAqvPFFMOhlU2U3SxE4CLasL99zP0ChINKp9XqzW/qo+F0/Jd4rZmddU2f
+M9Cx62cc0L5IlsHLVJj3zwHZzc/ifpBUeebB98IjoQAfiRkbX0Oe/c2TxtR4o/RH
+GWNeKCThdliZkXaLiOPswOV1BYfA00etorcY0CIy0aTaZgfvrYsJe4aT/hkF/JvF
+tHJ/iD67m8RhLysRL/w50+quVMluUDqJps0HhKrB9wzNJWrddWhvplVeuOXEJfTM
+i80W1JE4OApdISMEn56vRi+BMQMgIeYWznfyQnI4G3rUJQFMI5KzLxkvfYNTF3Ci
+3Am0KaJ7X2oLOq4Qc6CM3qDkvvId61COlfJb2Fo3ETnoT66mxcb6bjtz1WTWOopm
+UcmBKErRUKksINUxwuvP/VW007tXOjZH7wmiM2IW5LUZVkbhB1iE
+-----END CERTIFICATE-----`
+
+	secretKey = `-----BEGIN RSA PRIVATE KEY-----
+MIIEpgIBAAKCAQEA3LUv6RauFfFn4a2BNSTE5oQNhASBh2Lk0Gd0tfPcmTzJbohF
+wyAGskYj0NBRxnRVZdLPeoZIQyYSaiPWyeDITnXyKk3Nh9ZkxQ03YsbZCk9jIsp7
+8/ECdnYCCS4dpYGswu8b37dxUta+6AhEEte73ezrAhc+ZIy52yjcix4P5+vfhBf0
+EzBT8D7z+wZjji3F/A969EqphFwPz3KudkTOR6d0bQEVbN3xcg4lcj49RzwS4sPb
+q6ub52QrKcx8s+d9bqC/nhHLn1HM/eef+cxROedcIWZs5RvGmk/H+K2lcKL33gIc
+XgzSeunobV+8xwwoYk4GZroXjavUkgelKKjQBQIDAQABAoIBAQDcd/nmAwvfS4iT
+vTgGmDZAdsTxjXa+gSFEtTO21mUUhc5JpcLaSdGmn74DRzWI4oiz8EPlhuIEgbF/
+aVGT1AEDr3o6nAGloZqD5NHgz/XbALZs+IudgLEPGI6sEO74d3LWPvg/IAYJ1A5b
+xnYJxIscAyA2tHVVB+ZYcJbuORd2eSKeZSjfEfX8/DN8sKD+4DK9g/GiVlOJBG/d
+bSoZmcRv3HXpnSKTvCydkxbBliD/8H7jRvkCOi2VcYT9+08rucwXc6v+q9wiQ/b7
+hPdBn6KqDKRO9HPZYVkztlsdHXnthq16QyNPOk2umggfyXMIPhYBcW/dZ5xNqxBD
+KiInqjbBAoGBAP3s/FS8GvFJ80pwtA0AUtB7Lo3ZASSs9dq+Dr8binPpp/1qz3hJ
+Q/gRC9EP63MOWA2PK22D4qsjTfrBpqxLaalZCbCJGDGT+2knTN+qsOJ3//qI5zjj
+cFEcnWcJ3bI5eLAU/2GKViyXzdGlZxBbc4zKBUSyxMAUewr3PsqEO0SJAoGBAN6C
+vEYAbNuCZagtDrhhGYb+8rbSKZA7K4QjJcLTyZZ+z4ohWRW9tVyEXkszIwCRrs3y
+rhHJU+z1bJOXxIin1i5tCzVlG6iNLct9dm2Z5v4hbDGNw4HhIV0l+tXrVGhkM/1v
+vbRhldQA0H9iwWx+bKNS3lVLeUvYu4udmzrY74idAoGBAJ/8zQ9mZWNZwJxKXmdC
+qOsKcc6Vx46gG1dzID9wzs8xjNKylX2oS9bkhpl2elbH1trUNfyOeCZz3BH+KVGt
+QimdG+nKtx+lqWYbiOfz1/cYvIPR9j11r7KrYNEm+jPs2gm3cSC31IvMKbXJjSJV
+PHycXK1oJWcQgGXsWfenUOBhAoGBAKezvRa9Z04h/2A7ZWbNuCGosWHdD/pmvit/
+Ggy29q54sQ8Yhz39l109Xpwq1GyvYCJUj6FULe7gIo8yyat9Y83l3ZbGt4vXq/Y8
+fy+n2RMcOaE3iWywMyczYtQr45gyPYT73OzAx93bJ0l7MvEEb/jAklWS5r6lgOR/
+SumVayN5AoGBALLaG16NDrV2L3u/xzxw7uy5b3prpEi4wgZd4i72XaK+dMqtNVYy
+KlBs7O9y+fc4AIIn6JD+9tymB1TWEn1B+3Vv6jmtzbztuCQTbJ6rTT3CFcE6TdyJ
+8rYuG3/p2VkcG29TWbQARtj5ewv9p5QNfaecUzN+tps89YzawWQBanwI
+-----END RSA PRIVATE KEY-----`  // #nosec G101 -- ignore hardcoded test certs
+)
+
 // Internal script that exists on the host for running the DP in Docker.
 const fileRunSh = "run.sh"
 
@@ -224,6 +282,18 @@ func GetKongConfForShared() DockerInput {
 		ClientCert: certs.DefaultSharedCert,
 		CACert:     certs.DefaultSharedCert,
 	}
+}
+
+// GetKongConfForSharedWithSecrets is the same as GetKongConfForShared
+// but with the addition of KONG_MY_SECRET_* environment variabled
+// to be used for secrets management testing, as well as the additional
+// exposure of a port for ssl requests.
+func GetKongConfForSharedWithSecrets() DockerInput {
+	res := GetKongConfForShared()
+	res.EnvVars["KONG_MY_SECRET_CERT"] = secretCert
+	res.EnvVars["KONG_MY_SECRET_KEY"] = secretKey
+	res.EnvVars["KONG_PROXY_LISTEN"] = "0.0.0.0:8000, 0.0.0.0:8443 ssl"
+	return res
 }
 
 func GetKongConf() DockerInput {


### PR DESCRIPTION
This commit add an e2e test making sure that
secrets management using the Vault entity works as expected. This is done by injecting some environment variables in the DP (serving as recrets), create a Vault entity to 'stores' those secrets and have a
Certificate referencing the secrets.