### PR TITLE
chore: fix set-output usage due to deprecation

### DIFF
--- a/.github/workflows/dev-builds.yaml
+++ b/.github/workflows/dev-builds.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Set tag
         id: tag
         run: |
-          echo "::set-output name=tag::$(git rev-parse --short HEAD)"
+          echo "tag=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
       - name: Build and push docker image
         uses: docker/build-push-action@v3
         with:


### PR DESCRIPTION
This replaces set-output usage with the new environment variable files that are available with GitHub Actions.

see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/