### PR TITLE
chore: update workflow display names for GitHub Actions

### DIFF
--- a/.github/workflows/dev-builds.yaml
+++ b/.github/workflows/dev-builds.yaml
@@ -1,4 +1,4 @@
-name: dev-build
+name: Build and Push Development Docker Image [OSS]
 on:
   push:
     branches:

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -1,4 +1,4 @@
-name: integration-test
+name: Integration Tests [OSS]
 on: pull_request
 jobs:
   integration:

--- a/.github/workflows/label-check.yaml
+++ b/.github/workflows/label-check.yaml
@@ -1,4 +1,4 @@
-name: "PR label check"
+name: Pull Request Label Checker
 on:
   pull_request:
     types: [synchronize, opened, reopened, labeled, unlabeled]

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,4 +1,4 @@
-name: lint
+name: Lint [OSS]
 on: pull_request
 jobs:
   lint:

--- a/.github/workflows/release-push.yaml
+++ b/.github/workflows/release-push.yaml
@@ -1,4 +1,4 @@
-name: release-push
+name: Build and Push Release Docker Image [OSS]
 on:
   push:
     tags:

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -1,4 +1,4 @@
-name: govulncheck
+name: Go Vulnerability Checker
 on: pull_request
 jobs:
   govulncheck:

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -1,4 +1,4 @@
-name: unit-test
+name: Unit Tests [OSS]
 on: pull_request
 jobs:
   unit-test:


### PR DESCRIPTION
This updates the display names which are visible on GitHub Actions. The current names visible in the UI add to confusion when running any of them manually; the goal here is to remove that confusion.