### PR TITLE
chore: shorten Docker image workflow names

### DIFF
--- a/.github/workflows/dev-builds.yaml
+++ b/.github/workflows/dev-builds.yaml
@@ -1,4 +1,4 @@
-name: Build and Push Development Docker Image [OSS]
+name: Development Docker Image [OSS]
 on:
   push:
     branches:

--- a/.github/workflows/release-push.yaml
+++ b/.github/workflows/release-push.yaml
@@ -1,4 +1,4 @@
-name: Build and Push Release Docker Image [OSS]
+name: Release Docker Image [OSS]
 on:
   push:
     tags:


### PR DESCRIPTION
The GitHub UI does not have enough space to allow for the full name of the workflow to be displayed nor does it have a way currently to change the size of the panel.