### PR TITLE
fix: expand SNI validation to not allow IPs

### DIFF
--- a/internal/resource/route_test.go
+++ b/internal/resource/route_test.go
@@ -1264,6 +1264,52 @@ func TestRoute_Validate(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "setting invalid snis being an IP returns an error",
+			Route: func() Route {
+				r := NewRoute()
+				r.Route.Protocols = []string{
+					typedefs.ProtocolTLSPassthrough,
+				}
+				r.Route.Snis = []string{"1.2.3.4"}
+				_ = r.ProcessDefaults(context.Background())
+				return r
+			},
+			wantErr:                 true,
+			skipIfEnterpriseTesting: true,
+			Errs: []*model.ErrorDetail{
+				{
+					Type:  model.ErrorType_ERROR_TYPE_FIELD,
+					Field: "snis",
+					Messages: []string{
+						"must not be an IP: '1.2.3.4'",
+					},
+				},
+			},
+		},
+		{
+			name: "setting invalid snis with a port returns an error",
+			Route: func() Route {
+				r := NewRoute()
+				r.Route.Protocols = []string{
+					typedefs.ProtocolTLSPassthrough,
+				}
+				r.Route.Snis = []string{"sni:8080"}
+				_ = r.ProcessDefaults(context.Background())
+				return r
+			},
+			wantErr:                 true,
+			skipIfEnterpriseTesting: true,
+			Errs: []*model.ErrorDetail{
+				{
+					Type:  model.ErrorType_ERROR_TYPE_FIELD,
+					Field: "snis",
+					Messages: []string{
+						"must not contain a port: 'sni:8080'",
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		util.SkipTestIfEnterpriseTesting(t, tt.skipIfEnterpriseTesting)

--- a/internal/resource/sni_test.go
+++ b/internal/resource/sni_test.go
@@ -181,6 +181,50 @@ func TestSNI_Validate(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "SNI with invalid name being an IP returns an error",
+			SNI: func() SNI {
+				res := NewSNI()
+				_ = res.ProcessDefaults(context.Background())
+				res.SNI.Name = "1.2.3.4"
+				res.SNI.Certificate = &v1.Certificate{
+					Id: uuid.NewString(),
+				}
+				return res
+			},
+			wantErr: true,
+			Errs: []*v1.ErrorDetail{
+				{
+					Field: "name",
+					Type:  v1.ErrorType_ERROR_TYPE_FIELD,
+					Messages: []string{
+						"must not be an IP",
+					},
+				},
+			},
+		},
+		{
+			name: "SNI with invalid name with a port returns an error",
+			SNI: func() SNI {
+				res := NewSNI()
+				_ = res.ProcessDefaults(context.Background())
+				res.SNI.Name = "one-two.example.com:8080"
+				res.SNI.Certificate = &v1.Certificate{
+					Id: uuid.NewString(),
+				}
+				return res
+			},
+			wantErr: true,
+			Errs: []*v1.ErrorDetail{
+				{
+					Field: "name",
+					Type:  v1.ErrorType_ERROR_TYPE_FIELD,
+					Messages: []string{
+						"must not contain a port",
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Current validation allows setting IP addresses as
SNI's `name`, which causes the DP to reject the configuration
as that's now allowed:

```
  - in entry 1 of 'routes':
    in 'snis':
      - in entry 1 of 'snis': must not be an IP, context: ngx.timer
```

This commit makes sure that no IP or port can be set for
SNI's `name`.

Sample calls to Kong for both `snis` and `routes`:

```
$ echo '
paths:
    - /
snis:
    - localhost:8080
' | y2j | http ":8001/routes"
HTTP/1.1 400 Bad Request

{
    "code": 2,
    "fields": {
        "snis": [
            "must not have a port"
        ]
    },
    "message": "schema violation (snis.1: must not have a port)",
    "name": "schema violation"
}

$ echo '
paths:
    - /
snis:
    - 1.2.3.4
' | y2j | http ":8001/routes"
HTTP/1.1 400 Bad Request

{
    "code": 2,
    "fields": {
        "snis": [
            "must not be an IP"
        ]
    },
    "message": "schema violation (snis.1: must not be an IP)",
    "name": "schema violation"
}


$ echo '
name: 1.2.3.4
certificate:
    id: a431258d-de93-49fd-a7f1-3d6fede0ef3c
' | y2j | http ":8001/snis"
HTTP/1.1 400 Bad Request

{
    "code": 2,
    "fields": {
        "name": "must not be an IP"
    },
    "message": "schema violation (name: must not be an IP)",
    "name": "schema violation"
}

$ echo '
name: sni:8080
certificate:
    id: a431258d-de93-49fd-a7f1-3d6fede0ef3c
' | y2j | http ":8001/snis"
HTTP/1.1 400 Bad Request

{
    "code": 2,
    "fields": {
        "name": "must not have a port"
    },
    "message": "schema violation (name: must not have a port)",
    "name": "schema violation"
}
```