### PR TITLE
feat: get cluster ID on object store

### DIFF
--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -93,7 +93,7 @@ func Run(ctx context.Context, config ServerConfig) error {
 	defer persister.Close()
 
 	store := store.New(persister, logger.With(zap.String("component",
-		"store"))).ForCluster("default")
+		"store"))).ForCluster(store.DefaultCluster)
 	storeLoader := serverUtil.DefaultStoreLoader{Store: store}
 
 	instID, err := registerInstallation(ctx, store, logger)

--- a/internal/cmd/run_test.go
+++ b/internal/cmd/run_test.go
@@ -77,7 +77,7 @@ func TestRun_SetInstallationID(t *testing.T) {
 func setupTestDB(t *testing.T, logger *zap.Logger) store.Store {
 	p, err := util.GetPersister(t)
 	require.NoError(t, err)
-	return store.New(p, logger.With(zap.String("component", "test-store"))).ForCluster("default")
+	return store.New(p, logger.With(zap.String("component", "test-store"))).ForCluster(store.DefaultCluster)
 }
 
 func validUUID(id string) bool {

--- a/internal/plugin/validators/lua_validator_test.go
+++ b/internal/plugin/validators/lua_validator_test.go
@@ -76,7 +76,7 @@ func init() {
 func setupStoreLoader(t *testing.T) serverUtil.StoreLoader {
 	p, err := util.GetPersister(t)
 	require.NoError(t, err)
-	objectStore := store.New(p, log.Logger).ForCluster("default")
+	objectStore := store.New(p, log.Logger).ForCluster(store.DefaultCluster)
 	return serverUtil.DefaultStoreLoader{
 		Store: objectStore,
 	}
@@ -91,14 +91,14 @@ func insertPluginSchema(t *testing.T, name string, schema string, storeLoader se
 	pluginSchema.PluginSchema.Name = name
 	pluginSchema.PluginSchema.LuaSchema = schema
 
-	db, err := storeLoader.Load(context.Background(), &grpcModel.RequestCluster{Id: "default"})
+	db, err := storeLoader.Load(context.Background(), &grpcModel.RequestCluster{Id: store.DefaultCluster})
 	require.NoError(t, err)
 	return db.Create(context.Background(), pluginSchema)
 }
 
 func getValidContext() context.Context {
 	return context.WithValue(context.Background(), serverUtil.ContextKeyCluster,
-		&grpcModel.RequestCluster{Id: "default"})
+		&grpcModel.RequestCluster{Id: store.DefaultCluster})
 }
 
 func TestNewLuaValidator(t *testing.T) {

--- a/internal/server/admin/helpers_test.go
+++ b/internal/server/admin/helpers_test.go
@@ -34,7 +34,7 @@ func setup(t *testing.T) (*httptest.Server, func()) {
 	require.Nil(t, err)
 	objectStore := store.New(p, log.Logger)
 
-	server, cleanup := setupWithDB(t, objectStore.ForCluster("default"))
+	server, cleanup := setupWithDB(t, objectStore.ForCluster(store.DefaultCluster))
 	return server, func() {
 		cleanup()
 	}

--- a/internal/server/admin/node_test.go
+++ b/internal/server/admin/node_test.go
@@ -44,7 +44,7 @@ func TestNodeCreateUpsert(t *testing.T) {
 	objectStore := store.New(p, log.Logger)
 
 	storeLoader := serverUtil.DefaultStoreLoader{
-		Store: objectStore.ForCluster("default"),
+		Store: objectStore.ForCluster(store.DefaultCluster),
 	}
 	nodeService := &NodeService{
 		CommonOpts: CommonOpts{
@@ -132,13 +132,13 @@ func TestNodeDelete(t *testing.T) {
 	require.Nil(t, err)
 	objectStore := store.New(p, log.Logger)
 
-	db := objectStore.ForCluster("default")
+	db := objectStore.ForCluster(store.DefaultCluster)
 	ctx := context.Background()
 
 	handler, err := NewHandler(HandlerOpts{
 		Logger: log.Logger,
 		StoreLoader: serverUtil.DefaultStoreLoader{
-			Store: objectStore.ForCluster("default"),
+			Store: objectStore.ForCluster(store.DefaultCluster),
 		},
 		Validator: validator,
 	})
@@ -194,14 +194,14 @@ func TestNodeRead(t *testing.T) {
 	p, err := util.GetPersister(t)
 	require.Nil(t, err)
 	objectStore := store.New(p, log.Logger)
-	db := objectStore.ForCluster("default")
+	db := objectStore.ForCluster(store.DefaultCluster)
 
 	ctx := context.Background()
 
 	handler, err := NewHandler(HandlerOpts{
 		Logger: log.Logger,
 		StoreLoader: serverUtil.DefaultStoreLoader{
-			Store: objectStore.ForCluster("default"),
+			Store: objectStore.ForCluster(store.DefaultCluster),
 		},
 		Validator: validator,
 	})
@@ -409,7 +409,7 @@ func TestNodeList(t *testing.T) {
 	p, err := util.GetPersister(t)
 	require.Nil(t, err)
 	objectStore := store.New(p, log.Logger)
-	db := objectStore.ForCluster("default")
+	db := objectStore.ForCluster(store.DefaultCluster)
 
 	ctx := context.Background()
 
@@ -430,7 +430,7 @@ func TestNodeList(t *testing.T) {
 	handler, err := NewHandler(HandlerOpts{
 		Logger: log.Logger,
 		StoreLoader: serverUtil.DefaultStoreLoader{
-			Store: objectStore.ForCluster("default"),
+			Store: objectStore.ForCluster(store.DefaultCluster),
 		},
 		Validator: validator,
 	})
@@ -475,7 +475,7 @@ func TestNodeListWithStatus(t *testing.T) {
 	p, err := util.GetPersister(t)
 	require.Nil(t, err)
 	objectStore := store.New(p, log.Logger)
-	db := objectStore.ForCluster("default")
+	db := objectStore.ForCluster(store.DefaultCluster)
 
 	ctx := context.Background()
 
@@ -527,7 +527,7 @@ func TestNodeListWithStatus(t *testing.T) {
 	handler, err := NewHandler(HandlerOpts{
 		Logger: log.Logger,
 		StoreLoader: serverUtil.DefaultStoreLoader{
-			Store: objectStore.ForCluster("default"),
+			Store: objectStore.ForCluster(store.DefaultCluster),
 		},
 		Validator: validator,
 	})
@@ -604,9 +604,9 @@ func TestNodeService_listAllNodeStatus(t *testing.T) {
 	objectStore := store.New(p, log.Logger)
 
 	storeLoader := serverUtil.DefaultStoreLoader{
-		Store: objectStore.ForCluster("default"),
+		Store: objectStore.ForCluster(store.DefaultCluster),
 	}
-	db := objectStore.ForCluster("default")
+	db := objectStore.ForCluster(store.DefaultCluster)
 	nodeService := &NodeService{
 		CommonOpts: CommonOpts{
 			loggerFields: []zapcore.Field{zap.String("admin-service", "node")},

--- a/internal/server/admin/service_test.go
+++ b/internal/server/admin/service_test.go
@@ -11,6 +11,7 @@ import (
 	v1 "github.com/kong/koko/internal/gen/grpc/kong/admin/model/v1"
 	"github.com/kong/koko/internal/json"
 	"github.com/kong/koko/internal/model/json/validation/typedefs"
+	"github.com/kong/koko/internal/store"
 	"github.com/kong/koko/internal/test/util"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/wrapperspb"
@@ -780,7 +781,7 @@ func TestServiceListPagination(t *testing.T) {
 	t.Run("list size 1 page 1 returns 1 service total_count=10", func(t *testing.T) {
 		// Get First Page
 		body := c.GET("/v1/services").
-			WithQuery("cluster.id", "default").
+			WithQuery("cluster.id", store.DefaultCluster).
 			WithQuery("page.size", "1").
 			WithQuery("page.number", "1").
 			Expect().Status(http.StatusOK).JSON().Object()
@@ -794,7 +795,7 @@ func TestServiceListPagination(t *testing.T) {
 		require.Equal(t, headID, firstID)
 		// Go to last page and get the last element
 		body = c.GET("/v1/services").
-			WithQuery("cluster.id", "default").
+			WithQuery("cluster.id", store.DefaultCluster).
 			WithQuery("page.size", "1").
 			WithQuery("page.number", "10").
 			Expect().Status(http.StatusOK).JSON().Object()
@@ -810,7 +811,7 @@ func TestServiceListPagination(t *testing.T) {
 	t.Run("list page_size 2 and page 1 returns 2 services with total_count=10", func(t *testing.T) {
 		// Get First Page
 		body := c.GET("/v1/services").
-			WithQuery("cluster.id", "default").
+			WithQuery("cluster.id", store.DefaultCluster).
 			WithQuery("page.size", "2").
 			WithQuery("page.number", "1").
 			Expect().Status(http.StatusOK).JSON().Object()
@@ -824,7 +825,7 @@ func TestServiceListPagination(t *testing.T) {
 		require.Equal(t, headID, firstID)
 		// Go to last page and get the last element
 		body = c.GET("/v1/services").
-			WithQuery("cluster.id", "default").
+			WithQuery("cluster.id", store.DefaultCluster).
 			WithQuery("page.size", "2").
 			WithQuery("page.number", "5").
 			Expect().Status(http.StatusOK).JSON().Object()
@@ -839,7 +840,7 @@ func TestServiceListPagination(t *testing.T) {
 	t.Run("list page_size 3 and page 1 returns 3 services with total_count=10", func(t *testing.T) {
 		// Get First Page
 		body := c.GET("/v1/services").
-			WithQuery("cluster.id", "default").
+			WithQuery("cluster.id", store.DefaultCluster).
 			WithQuery("page.size", "3").
 			WithQuery("page.number", "1").
 			Expect().Status(http.StatusOK).JSON().Object()
@@ -852,7 +853,7 @@ func TestServiceListPagination(t *testing.T) {
 		require.Equal(t, headID, firstID)
 		// Go to last page and get the last element
 		body = c.GET("/v1/services").
-			WithQuery("cluster.id", "default").
+			WithQuery("cluster.id", store.DefaultCluster).
 			WithQuery("page.size", "3").
 			WithQuery("page.number", "4").
 			Expect().Status(http.StatusOK).JSON().Object()
@@ -867,7 +868,7 @@ func TestServiceListPagination(t *testing.T) {
 	t.Run("list page_size 4 and page 1 returns 4 services with total_count=10", func(t *testing.T) {
 		// Get First Page
 		body := c.GET("/v1/services").
-			WithQuery("cluster.id", "default").
+			WithQuery("cluster.id", store.DefaultCluster).
 			WithQuery("page.size", "4").
 			WithQuery("page.number", "1").
 			Expect().Status(http.StatusOK).JSON().Object()
@@ -880,7 +881,7 @@ func TestServiceListPagination(t *testing.T) {
 		require.Equal(t, headID, firstID)
 		// Go to last page and get the last element
 		body = c.GET("/v1/services").
-			WithQuery("cluster.id", "default").
+			WithQuery("cluster.id", store.DefaultCluster).
 			WithQuery("page.size", "4").
 			WithQuery("page.number", "3").
 			Expect().Status(http.StatusOK).JSON().Object()
@@ -895,7 +896,7 @@ func TestServiceListPagination(t *testing.T) {
 	t.Run("list page_size 10 and page 1 returns 10 services with total_count=10", func(t *testing.T) {
 		// Get First Page
 		body := c.GET("/v1/services").
-			WithQuery("cluster.id", "default").
+			WithQuery("cluster.id", store.DefaultCluster).
 			WithQuery("page.size", "10").
 			WithQuery("page.number", "1").
 			Expect().Status(http.StatusOK).JSON().Object()
@@ -913,7 +914,7 @@ func TestServiceListPagination(t *testing.T) {
 	})
 	t.Run("list page_size 10 and page 10 returns no services", func(t *testing.T) {
 		body := c.GET("/v1/services").
-			WithQuery("cluster.id", "default").
+			WithQuery("cluster.id", store.DefaultCluster).
 			WithQuery("page.size", "10").
 			WithQuery("page.number", "10").
 			Expect().Status(http.StatusOK).JSON().Object()
@@ -922,7 +923,7 @@ func TestServiceListPagination(t *testing.T) {
 	t.Run("list page_size 10 and no Page returns 10 services with total_count=10", func(t *testing.T) {
 		// Get First Page
 		body := c.GET("/v1/services").
-			WithQuery("cluster.id", "default").
+			WithQuery("cluster.id", store.DefaultCluster).
 			WithQuery("page.size", "10").
 			Expect().Status(http.StatusOK).JSON().Object()
 		items := body.Value("items").Array()
@@ -940,7 +941,7 @@ func TestServiceListPagination(t *testing.T) {
 	t.Run("list no page_size and Page 1 returns 10 services with total_count=10", func(t *testing.T) {
 		// Get First Page
 		body := c.GET("/v1/services").
-			WithQuery("cluster.id", "default").
+			WithQuery("cluster.id", store.DefaultCluster).
 			WithQuery("page.number", "1").
 			Expect().Status(http.StatusOK).JSON().Object()
 		items := body.Value("items").Array()
@@ -958,7 +959,7 @@ func TestServiceListPagination(t *testing.T) {
 	t.Run("list page_size 11 and page 1 returns 10 services with total_count=10", func(t *testing.T) {
 		// Get First Page
 		body := c.GET("/v1/services").
-			WithQuery("cluster.id", "default").
+			WithQuery("cluster.id", store.DefaultCluster).
 			WithQuery("page.size", "11").
 			WithQuery("page.number", "1").
 			Expect().Status(http.StatusOK).JSON().Object()
@@ -977,7 +978,7 @@ func TestServiceListPagination(t *testing.T) {
 	t.Run("list > 1001 page size and page 1 returns error", func(t *testing.T) {
 		// Get First Page
 		body := c.GET("/v1/services").
-			WithQuery("cluster.id", "default").
+			WithQuery("cluster.id", store.DefaultCluster).
 			WithQuery("page.size", "1001").
 			WithQuery("page.number", "1").
 			Expect().Status(http.StatusBadRequest).JSON().Object()
@@ -987,7 +988,7 @@ func TestServiceListPagination(t *testing.T) {
 	t.Run("list page_size 10 and page < 0 returns error", func(t *testing.T) {
 		// Get First Page
 		body := c.GET("/v1/services").
-			WithQuery("cluster.id", "default").
+			WithQuery("cluster.id", store.DefaultCluster).
 			WithQuery("page.size", "10").
 			WithQuery("page.number", "-1").
 			Expect().Status(http.StatusBadRequest).JSON().Object()

--- a/internal/server/kong/ws/manager.go
+++ b/internal/server/kong/ws/manager.go
@@ -49,7 +49,7 @@ type Cluster interface {
 type DefaultCluster struct{}
 
 func (d DefaultCluster) Get() string {
-	return "default"
+	return store.DefaultCluster
 }
 
 // nodeStatusCacheSize sets the size of the node status cache size.

--- a/internal/server/kong/ws/manager_test.go
+++ b/internal/server/kong/ws/manager_test.go
@@ -25,14 +25,14 @@ import (
 func TestCleanupNodes(t *testing.T) {
 	persister, err := util.GetPersister(t)
 	require.Nil(t, err)
-	store := store.New(persister, log.Logger).ForCluster("default")
+	db := store.New(persister, log.Logger).ForCluster(store.DefaultCluster)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	s := grpc.NewServer()
 	admin.RegisterAdminService(s, admin.HandlerOpts{
 		Logger:      log.Logger,
-		StoreLoader: serverUtil.DefaultStoreLoader{Store: store},
+		StoreLoader: serverUtil.DefaultStoreLoader{Store: db},
 	})
 
 	l := setup()

--- a/internal/server/kong/ws/relay_event_streamer_test.go
+++ b/internal/server/kong/ws/relay_event_streamer_test.go
@@ -59,11 +59,11 @@ func (r *relayEventHandler) OnEvent(ctx context.Context, e Event) error {
 func TestRelayEventStreamer_RegisterUnregister(t *testing.T) {
 	persister, err := util.GetPersister(t)
 	require.Nil(t, err)
-	store := store.New(persister, log.Logger).ForCluster("default")
+	db := store.New(persister, log.Logger).ForCluster(store.DefaultCluster)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	opts := relay.EventServiceOpts{
-		Store:  store,
+		Store:  db,
 		Logger: log.Logger,
 	}
 	server := relay.NewEventService(ctx, opts)
@@ -164,7 +164,7 @@ func TestRelayEventStreamer_RegisterUnregister(t *testing.T) {
 		res := resource.NewService()
 		res.Service.Host = "example.com"
 		res.Service.Path = "/"
-		err = store.Create(ctx, res)
+		err = db.Create(ctx, res)
 		require.NoError(t, err)
 
 		util.WaitFunc(t, func() error {
@@ -194,7 +194,7 @@ func TestRelayEventStreamer_RegisterUnregister(t *testing.T) {
 		res := resource.NewService()
 		res.Service.Host = "example.com"
 		res.Service.Path = "/"
-		err = store.Create(ctx, res)
+		err = db.Create(ctx, res)
 		require.NoError(t, err)
 
 		// Due to refresh interval for EventService defaulting to 5s and not being configurable

--- a/internal/server/relay/event_service_test.go
+++ b/internal/server/relay/event_service_test.go
@@ -22,11 +22,11 @@ import (
 func TestEventService(t *testing.T) {
 	persister, err := util.GetPersister(t)
 	require.Nil(t, err)
-	store := store.New(persister, log.Logger).ForCluster("default")
+	db := store.New(persister, log.Logger).ForCluster(store.DefaultCluster)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	opts := EventServiceOpts{
-		Store:  store,
+		Store:  db,
 		Logger: log.Logger,
 	}
 	server := NewEventService(ctx, opts)
@@ -61,13 +61,13 @@ func TestEventService(t *testing.T) {
 			defer cancel()
 			stream, err := client.FetchReconfigureEvents(ctx,
 				&relay.FetchReconfigureEventsRequest{
-					Cluster: &model.RequestCluster{Id: "default"},
+					Cluster: &model.RequestCluster{Id: store.DefaultCluster},
 				})
 			require.Nil(t, err)
 			res := resource.NewService()
 			res.Service.Host = "example.com"
 			res.Service.Path = "/"
-			err = store.Create(ctx, res)
+			err = db.Create(ctx, res)
 			require.Nil(t, err)
 
 			event, err := stream.Recv()

--- a/internal/server/relay/status_service_test.go
+++ b/internal/server/relay/status_service_test.go
@@ -23,7 +23,7 @@ func TestRelayStatusServiceUpdateNodeStatus(t *testing.T) {
 	ctx := context.Background()
 	persister, err := util.GetPersister(t)
 	require.Nil(t, err)
-	db := store.New(persister, log.Logger).ForCluster("default")
+	db := store.New(persister, log.Logger).ForCluster(store.DefaultCluster)
 	opts := StatusServiceOpts{
 		StoreLoader: serverUtil.DefaultStoreLoader{Store: db},
 		Logger:      log.Logger,

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -17,12 +17,19 @@ import (
 
 const DefaultOperationTimeout = 15 * time.Second
 
+// DefaultCluster defines the cluster ID when one has not been passed in when instantiating a Store object.
+const DefaultCluster = "default"
+
 var (
 	errNoObject = fmt.Errorf("no object")
 	ErrNotFound = fmt.Errorf("not found")
 )
 
 type Store interface {
+	// Cluster returns the store's underlining cluster ID. When no specific cluster
+	// is associated to the Store, the returned value will be DefaultCluster.
+	Cluster() string
+
 	Create(context.Context, model.Object, ...CreateOptsFunc) error
 	Upsert(context.Context, model.Object, ...CreateOptsFunc) error
 	Read(context.Context, model.Object, ...ReadOptsFunc) error
@@ -86,6 +93,14 @@ func (s *ObjectStore) withTx(ctx context.Context,
 		return err
 	}
 	return tx.Commit()
+}
+
+// Cluster implements the Store interface.
+func (s *ObjectStore) Cluster() string {
+	if s.cluster != "" {
+		return s.cluster
+	}
+	return DefaultCluster
 }
 
 func (s *ObjectStore) Create(ctx context.Context, object model.Object,

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -26,7 +26,7 @@ func TestCreate(t *testing.T) {
 	persister, err := util.GetPersister(t)
 	require.Nil(t, err)
 	ctx := context.Background()
-	s := New(persister, log.Logger).ForCluster("default")
+	s := New(persister, log.Logger).ForCluster(DefaultCluster)
 	sid := uuid.NewString()
 	t.Run("creating a nil object fails", func(t *testing.T) {
 		err := s.Create(ctx, nil)
@@ -165,7 +165,7 @@ func TestRead(t *testing.T) {
 	persister, err := util.GetPersister(t)
 	require.Nil(t, err)
 	ctx := context.Background()
-	s := New(persister, log.Logger).ForCluster("default")
+	s := New(persister, log.Logger).ForCluster(DefaultCluster)
 	svc := resource.NewService()
 	sid := uuid.NewString()
 	svc.Service = &v1.Service{
@@ -225,7 +225,7 @@ func TestRead(t *testing.T) {
 func TestDelete(t *testing.T) {
 	persister, err := util.GetPersister(t)
 	require.Nil(t, err)
-	s := New(persister, log.Logger).ForCluster("default")
+	s := New(persister, log.Logger).ForCluster(DefaultCluster)
 	t.Run("deleting an existing object succeeds", func(t *testing.T) {
 		svc := resource.NewService()
 		id := uuid.NewString()
@@ -255,7 +255,7 @@ func TestDelete(t *testing.T) {
 		ctx := context.Background()
 		persister, err := util.GetPersister(t)
 		require.Nil(t, err)
-		s := New(persister, log.Logger).ForCluster("default")
+		s := New(persister, log.Logger).ForCluster(DefaultCluster)
 		svc := resource.NewService()
 		sid := uuid.NewString()
 		svc.Service = &v1.Service{
@@ -290,7 +290,7 @@ func TestDelete(t *testing.T) {
 func TestUpsert(t *testing.T) {
 	persister, err := util.GetPersister(t)
 	require.Nil(t, err)
-	s := New(persister, log.Logger).ForCluster("default")
+	s := New(persister, log.Logger).ForCluster(DefaultCluster)
 	ctx := context.Background()
 
 	t.Run("upsert a nil object fails", func(t *testing.T) {
@@ -452,7 +452,7 @@ func TestUpsert(t *testing.T) {
 			ctx := context.Background()
 			persister, err := util.GetPersister(t)
 			require.Nil(t, err)
-			s := New(persister, log.Logger).ForCluster("default")
+			s := New(persister, log.Logger).ForCluster(DefaultCluster)
 			svc := resource.NewService()
 			serviceID := uuid.NewString()
 			svc.Service = &v1.Service{
@@ -520,7 +520,7 @@ func TestUpsert(t *testing.T) {
 func TestList(t *testing.T) {
 	persister, err := util.GetPersister(t)
 	require.Nil(t, err)
-	s := New(persister, log.Logger).ForCluster("default")
+	s := New(persister, log.Logger).ForCluster(DefaultCluster)
 	t.Run("list returns zero results without an error", func(t *testing.T) {
 		svcs := resource.NewList(resource.TypeService)
 		err = s.List(context.Background(), svcs)
@@ -650,7 +650,7 @@ func TestForCluster(t *testing.T) {
 func TestUpdateEvent(t *testing.T) {
 	persister, err := util.GetPersister(t)
 	require.Nil(t, err)
-	s := New(persister, log.Logger).ForCluster("default")
+	s := New(persister, log.Logger).ForCluster(DefaultCluster)
 	ctx := context.Background()
 	t.Run("empty cluster has no update event", func(t *testing.T) {
 		e := event.New()
@@ -752,7 +752,7 @@ func TestUpdateEvent(t *testing.T) {
 func TestUpdateEventForNode(t *testing.T) {
 	persister, err := util.GetPersister(t)
 	require.Nil(t, err)
-	s := New(persister, log.Logger).ForCluster("default")
+	s := New(persister, log.Logger).ForCluster(DefaultCluster)
 	ctx := context.Background()
 	t.Run("creating node doesn't create an update event", func(t *testing.T) {
 		node := resource.NewNode()
@@ -811,7 +811,7 @@ func TestStoredValue(t *testing.T) {
 		ctx := context.Background()
 		persister, err := util.GetPersister(t)
 		require.Nil(t, err)
-		s := New(persister, log.Logger).ForCluster("default")
+		s := New(persister, log.Logger).ForCluster(DefaultCluster)
 		route := resource.NewRoute()
 		id := uuid.NewString()
 		route.Route = &v1.Route{
@@ -839,7 +839,7 @@ func TestStoredValue(t *testing.T) {
 func TestPagination(t *testing.T) {
 	persister, err := util.GetPersister(t)
 	require.Nil(t, err)
-	store := New(persister, log.Logger).ForCluster("default")
+	store := New(persister, log.Logger).ForCluster(DefaultCluster)
 	ctx := context.Background()
 	// Create 10 services and perform the pagination
 	svcName := "myservice-%d"

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/kong/koko/internal/resource"
 	"github.com/kong/koko/internal/store/event"
 	"github.com/kong/koko/internal/test/util"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )
@@ -622,7 +623,9 @@ func TestNew(t *testing.T) {
 	})
 	t.Run("does not panic when both provided", func(t *testing.T) {
 		require.NotPanics(t, func() {
-			require.NotNil(t, New(persister, log.Logger))
+			store := New(persister, log.Logger)
+			require.NotNil(t, store)
+			assert.Equal(t, DefaultCluster, store.Cluster())
 		})
 	})
 }
@@ -640,6 +643,8 @@ func TestForCluster(t *testing.T) {
 	require.Panics(t, func() {
 		s.clusterKey("foo")
 	})
+
+	assert.Equal(t, "foo", s.ForCluster("foo").Cluster())
 }
 
 func TestUpdateEvent(t *testing.T) {
@@ -1003,6 +1008,12 @@ func TestFullListPaging(t *testing.T) {
 		require.Equal(t, expectedKeysBatchOne, keysAsStrings)
 		tx.Rollback()
 	})
+}
+
+func TestObjectStore_Cluster(t *testing.T) {
+	assert.Equal(t, DefaultCluster, (&ObjectStore{}).Cluster())
+	assert.Equal(t, DefaultCluster, (&ObjectStore{cluster: DefaultCluster}).Cluster())
+	assert.Equal(t, "test-cluster", (&ObjectStore{cluster: "test-cluster"}).Cluster())
 }
 
 func contains(repo []string, search string) bool {

--- a/internal/store/timestamp_test.go
+++ b/internal/store/timestamp_test.go
@@ -35,7 +35,7 @@ func TestAddTS(t *testing.T) {
 	t.Run("timestamps are added to persisted resource", func(t *testing.T) {
 		persister, err := util.GetPersister(t)
 		require.Nil(t, err)
-		s := New(persister, log.Logger).ForCluster("default")
+		s := New(persister, log.Logger).ForCluster(DefaultCluster)
 		svc := resource.NewService()
 		id := uuid.NewString()
 		svc.Service = &v1.Service{
@@ -51,7 +51,7 @@ func TestAddTS(t *testing.T) {
 	t.Run("timestamps provided in input are overridden", func(t *testing.T) {
 		persister, err := util.GetPersister(t)
 		require.Nil(t, err)
-		s := New(persister, log.Logger).ForCluster("default")
+		s := New(persister, log.Logger).ForCluster(DefaultCluster)
 		svc := resource.NewService()
 		id := uuid.NewString()
 		svc.Service = &v1.Service{


### PR DESCRIPTION
As briefly spoken about [here](https://github.com/Kong/koko/pull/472#discussion_r996220118), we're introducing the ability to get the cluster ID on the object store, which can mostly be used for things like unit testing & general observability like logging.

This is broken up into two commits to allow for easier review.