### PR TITLE
feat: add dataplane metrics for control plane

### DIFF
--- a/internal/server/kong/ws/config/configuration.go
+++ b/internal/server/kong/ws/config/configuration.go
@@ -57,10 +57,9 @@ func (l *KongConfigurationLoader) Load(ctx context.Context, clusterID string) (C
 		err := m.Mutate(ctx, MutatorOpts{ClusterID: clusterID},
 			configTable)
 		metrics.Histogram(
-			"data_plane_config_mutation_individual_duration_seconds",
+			"config_mutation_individual_duration_seconds",
 			time.Since(mutationStartTime).Seconds(),
 			metrics.Tag{Key: "status", Value: lo.Ternary(err == nil, "success", "fail")},
-			metrics.Tag{Key: "protocol", Value: "ws"},
 			metrics.Tag{Key: "mutator_name", Value: m.Name()},
 		)
 		if err != nil {

--- a/internal/server/kong/ws/manager.go
+++ b/internal/server/kong/ws/manager.go
@@ -33,12 +33,12 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-var totalMutationTime = metricsv2.NewHistogram(
+var totalMutationDuration = metricsv2.NewHistogram(
 	prometheus.NewRegistry(),
 	metricsv2.HistogramOpts{
 		Subsystem:  "cp",
 		Name:       "data_plane_config_mutation_time_total",
-		Help:       "Total duration in ms it takes to reconfigure a dataplane payload",
+		Help:       "Total duration in ms it takes to mutate a dataplane payload",
 		LabelNames: []string{"status"},
 	})
 
@@ -489,14 +489,14 @@ func (m *Manager) reconcileKongPayload(ctx context.Context) error {
 	config, err := m.configLoader.Load(ctx, m.Cluster.Get())
 	mutationDuration := time.Since(mutationStartTime).Milliseconds()
 	if err != nil {
-		totalMutationTime.Observe(float64(mutationDuration),
+		totalMutationDuration.Observe(float64(mutationDuration),
 			metricsv2.Label{
 				Key:   "status",
 				Value: "fail",
 			})
 		return err
 	}
-	totalMutationTime.Observe(float64(mutationDuration),
+	totalMutationDuration.Observe(float64(mutationDuration),
 		metricsv2.Label{
 			Key:   "status",
 			Value: "success",

--- a/internal/server/kong/ws/manager.go
+++ b/internal/server/kong/ws/manager.go
@@ -478,10 +478,9 @@ func (m *Manager) reconcileKongPayload(ctx context.Context) error {
 	mutationStartTime := time.Now()
 	config, err := m.configLoader.Load(ctx, m.Cluster.Get())
 	metrics.Histogram(
-		"data_plane_config_mutation_total_duration_seconds",
+		"config_mutation_total_duration_seconds",
 		time.Since(mutationStartTime).Seconds(),
 		metrics.Tag{Key: "status", Value: lo.Ternary(err == nil, "success", "fail")},
-		metrics.Tag{Key: "protocol", Value: "ws"},
 	)
 	if err != nil {
 		return err

--- a/internal/server/kong/ws/node.go
+++ b/internal/server/kong/ws/node.go
@@ -15,9 +15,8 @@ import (
 	"github.com/kong/go-wrpc/wrpc"
 	config_service "github.com/kong/koko/internal/gen/wrpc/kong/services/config/v1"
 	"github.com/kong/koko/internal/json"
-	metricsv2 "github.com/kong/koko/internal/metrics/v2"
+	"github.com/kong/koko/internal/metrics"
 	"github.com/kong/koko/internal/server/kong/ws/config"
-	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
 )
 
@@ -29,16 +28,6 @@ const (
 )
 
 var hashRegex = regexp.MustCompile(hashRegexPat)
-
-var configSize = metricsv2.NewHistogram(
-	prometheus.NewRegistry(),
-	metricsv2.HistogramOpts{
-		Subsystem:  "cp",
-		Name:       "data_plane_config_size",
-		Help:       "Size (in bytes) of a dataplane config",
-		Buckets:    []float64{10, 100, 200, 300, 400, 500, 1000, 2500, 5000, 10000, 15000, 25000, 50000, 100000, 1000000},
-		LabelNames: []string{"dp_version"},
-	})
 
 func (s sum) String() string {
 	return string(s[:])
@@ -198,10 +187,12 @@ func (n *Node) readThread() error {
 
 func (n *Node) sendConfig(ctx context.Context, payload *Payload) error {
 	content, err := n.getPayload(ctx, payload)
-	configSize.Observe(float64(unsafe.Sizeof(content)), metricsv2.Label{
-		Key:   "dp_version",
-		Value: n.Version,
-	})
+	metrics.Histogram("data_plane_config_size",
+		float64(unsafe.Sizeof(content)),
+		metrics.Tag{
+			Key:   "dp_version",
+			Value: n.Version,
+		})
 	if err != nil {
 		return fmt.Errorf("unable to gather payload: %w", err)
 	}

--- a/internal/server/kong/ws/node.go
+++ b/internal/server/kong/ws/node.go
@@ -9,13 +9,11 @@ import (
 	"net"
 	"regexp"
 	"sync"
-	"unsafe"
 
 	"github.com/gorilla/websocket"
 	"github.com/kong/go-wrpc/wrpc"
 	config_service "github.com/kong/koko/internal/gen/wrpc/kong/services/config/v1"
 	"github.com/kong/koko/internal/json"
-	"github.com/kong/koko/internal/metrics"
 	"github.com/kong/koko/internal/server/kong/ws/config"
 	"go.uber.org/zap"
 )
@@ -187,12 +185,6 @@ func (n *Node) readThread() error {
 
 func (n *Node) sendConfig(ctx context.Context, payload *Payload) error {
 	content, err := n.getPayload(ctx, payload)
-	metrics.Histogram("data_plane_config_size",
-		float64(unsafe.Sizeof(content)),
-		metrics.Tag{
-			Key:   "dp_version",
-			Value: n.Version,
-		})
 	if err != nil {
 		return fmt.Errorf("unable to gather payload: %w", err)
 	}

--- a/internal/server/kong/ws/payload.go
+++ b/internal/server/kong/ws/payload.go
@@ -130,7 +130,7 @@ func (p *Payload) configForVersion(version string) (cacheEntry, error) {
 				})
 		}
 		configUpdateProcessingDuration := time.Since(configUpdateProcessingStartTime).Seconds()
-		metrics.Histogram("version_compatibility_configuration_duration_seconds", configUpdateProcessingDuration,
+		metrics.Histogram("configuration_transformation_duration_seconds", configUpdateProcessingDuration,
 			metrics.Tag{Key: "dp_version", Value: version},
 			metrics.Tag{Key: "status", Value: lo.Ternary(err == nil, "success", "fail")},
 		)

--- a/internal/server/kong/ws/payload.go
+++ b/internal/server/kong/ws/payload.go
@@ -130,7 +130,7 @@ func (p *Payload) configForVersion(version string) (cacheEntry, error) {
 				})
 		}
 		configUpdateProcessingDuration := time.Since(configUpdateProcessingStartTime).Seconds()
-		metrics.Histogram("configuration_transformation_duration_seconds", configUpdateProcessingDuration,
+		metrics.Histogram("version_compatibility_configuration_duration_seconds", configUpdateProcessingDuration,
 			metrics.Tag{Key: "dp_version", Value: version},
 			metrics.Tag{Key: "status", Value: lo.Ternary(err == nil, "success", "fail")},
 		)

--- a/internal/server/kong/ws/payload.go
+++ b/internal/server/kong/ws/payload.go
@@ -130,10 +130,9 @@ func (p *Payload) configForVersion(version string) (cacheEntry, error) {
 				})
 		}
 		configUpdateProcessingDuration := time.Since(configUpdateProcessingStartTime).Seconds()
-		metrics.Histogram("data_plane_version_compatibility_duration_seconds", configUpdateProcessingDuration,
+		metrics.Histogram("configuration_transformation_duration_seconds", configUpdateProcessingDuration,
 			metrics.Tag{Key: "dp_version", Value: version},
 			metrics.Tag{Key: "status", Value: lo.Ternary(err == nil, "success", "fail")},
-			metrics.Tag{Key: "protocol", Value: "ws"},
 		)
 		// cache changes
 		err = p.configHashToChanges.Set(unversionedConfig.Hash+version, changes)

--- a/internal/server/kong/ws/payload.go
+++ b/internal/server/kong/ws/payload.go
@@ -138,16 +138,12 @@ func (p *Payload) configForVersion(version string) (cacheEntry, error) {
 		}
 		// cache it
 		err = p.configCache.store(version, entry)
-		configUpdateProcessingDuration := time.Since(configUpdateProcessingStartTime).Milliseconds()
-		metrics.Histogram("data_plane_version_compatibility_duration", float64(configUpdateProcessingDuration),
-			metrics.Tag{
-				Key:   "dp_version",
-				Value: version,
-			},
-			metrics.Tag{
-				Key:   "status",
-				Value: "success",
-			})
+		configUpdateProcessingDuration := time.Since(configUpdateProcessingStartTime).Seconds()
+		metrics.Histogram("data_plane_version_compatibility_duration_seconds", configUpdateProcessingDuration,
+			metrics.Tag{Key: "dp_version", Value: version},
+			metrics.Tag{Key: "status", Value: "success"},
+			metrics.Tag{Key: "protocol", Value: "ws"},
+		)
 		if err != nil {
 			p.logger.Error("failed to store configuration from cache",
 				zap.Error(err),

--- a/internal/server/kong/ws/server.go
+++ b/internal/server/kong/ws/server.go
@@ -122,13 +122,12 @@ func (h websocketHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		loggerWithNode.Error("failed to upgrade websocket connection", zap.Error(err))
 		return
 	}
-	dpConnectionDuration := time.Since(dpConnectStartTime).Milliseconds()
-	metrics.Histogram("data_plane_time_to_connect",
-		float64(dpConnectionDuration),
-		metrics.Tag{
-			Key:   "dp_version",
-			Value: nodeVersion,
-		})
+	// Tracks how long it takes to establish the connection between the control plane and the data plane.
+	metrics.Histogram("data_plane_connect_duration_seconds",
+		time.Since(dpConnectStartTime).Seconds(),
+		metrics.Tag{Key: "dp_version", Value: nodeVersion},
+		metrics.Tag{Key: "protocol", Value: "ws"},
+	)
 
 	node, err := NewNode(nodeOpts{
 		id:         nodeID,

--- a/internal/server/kong/ws/server.go
+++ b/internal/server/kong/ws/server.go
@@ -123,10 +123,9 @@ func (h websocketHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Tracks how long it takes to establish the connection between the control plane and the data plane.
-	metrics.Histogram("data_plane_connect_duration_seconds",
+	metrics.Histogram("wrpc_connection_setup_duration_seconds",
 		time.Since(dpConnectStartTime).Seconds(),
 		metrics.Tag{Key: "dp_version", Value: nodeVersion},
-		metrics.Tag{Key: "protocol", Value: "ws"},
 	)
 
 	node, err := NewNode(nodeOpts{

--- a/internal/server/kong/ws/server.go
+++ b/internal/server/kong/ws/server.go
@@ -28,7 +28,7 @@ var dpTimeToConnect = metricsv2.NewHistogram(
 		Subsystem:  "cp",
 		Name:       "data_plane_time_to_connect",
 		Help:       "Time it takes for initial connection between a control plane and a data plane",
-		LabelNames: []string{"dp_version", "protocol"},
+		LabelNames: []string{"dp_version"},
 	})
 
 type HandlerOpts struct {

--- a/internal/server/kong/ws/server.go
+++ b/internal/server/kong/ws/server.go
@@ -123,7 +123,7 @@ func (h websocketHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Tracks how long it takes to establish the connection between the control plane and the data plane.
-	metrics.Histogram("wrpc_connection_setup_duration_seconds",
+	metrics.Histogram("connection_setup_duration_seconds",
 		time.Since(dpConnectStartTime).Seconds(),
 		metrics.Tag{Key: "dp_version", Value: nodeVersion},
 	)


### PR DESCRIPTION
    Adds the following metrics:
    * duration (s) to establish initial connection between dp and cp
    * duration (s) of individual config mutations
    * duration (s) of total aggregate config mutations
    * duration (s) of version compat cache miss path