### PR TITLE
feat: process schema defaults before peforming schema validation

### DIFF
--- a/internal/server/admin/schemas_service.go
+++ b/internal/server/admin/schemas_service.go
@@ -174,7 +174,10 @@ func (s *SchemasService) validateSchema(ctx context.Context, item proto.Message)
 		// registered (via `model.RegisterType()`), this would never error.
 		return err
 	}
-
+	// Process entity defaults before performing schema validation.
+	if err := obj.ProcessDefaults(ctx); err != nil {
+		return s.err(ctx, err)
+	}
 	return s.err(ctx, obj.Validate(ctx))
 }
 

--- a/internal/server/admin/schemas_test.go
+++ b/internal/server/admin/schemas_test.go
@@ -277,23 +277,17 @@ func TestValidateJSONSchema(t *testing.T) {
 
 		body := res.JSON().Object()
 		body.Value("message").String().Equal("validation error")
-		body.Value("details").Array().Length().Equal(4)
+		body.Value("details").Array().Length().Equal(3)
 		errRes := body.Value("details").Array()
 
-		entityErr := errRes.Element(0).Object()
-		entityErr.Value("type").String().Equal(v1.ErrorType_ERROR_TYPE_ENTITY.String())
-		messages := entityErr.Value("messages").Array()
-		messages.Length().Equal(1)
-		messages.First().String().Equal("missing properties: 'id'")
-
-		createdAtErr := errRes.Element(1).Object()
+		createdAtErr := errRes.Element(0).Object()
 		createdAtErr.Value("type").String().Equal(v1.ErrorType_ERROR_TYPE_FIELD.String())
 		createdAtErr.Value("field").String().Equal("created_at")
-		messages = createdAtErr.Value("messages").Array()
+		messages := createdAtErr.Value("messages").Array()
 		messages.Length().Equal(1)
 		messages.First().String().Equal("must be >= 1 but found -1")
 
-		customIDErr := errRes.Element(2).Object()
+		customIDErr := errRes.Element(1).Object()
 		customIDErr.Value("type").String().Equal(v1.ErrorType_ERROR_TYPE_FIELD.String())
 		customIDErr.Value("field").String().Equal("custom_id")
 		messages = customIDErr.Value("messages").Array()
@@ -302,7 +296,7 @@ func TestValidateJSONSchema(t *testing.T) {
 			`must match pattern '^[0-9a-zA-Z.\-_~\(\)#%@|+]+(?: [0-9a-zA-Z.\-_~\(\)#%@|+]+)*$'`,
 		)
 
-		tagsErr := errRes.Element(3).Object()
+		tagsErr := errRes.Element(2).Object()
 		tagsErr.Value("type").String().Equal(v1.ErrorType_ERROR_TYPE_FIELD.String())
 		tagsErr.Value("field").String().Equal("tags[1]")
 		messages = tagsErr.Value("messages").Array()


### PR DESCRIPTION
Right now Koko requires a schema to include all required fields in order to pass validation via the `/v1/schemas/json/<entity>/validate` endpoint, regardless of these fields having schema defaults that are injected at run time.

For example:
```
$ echo '
id: 7f27869a-be49-406b-83f0-1c14becc1508
name: foo
host: example.com
path: /
' | y2j | http ":3000/v1/schemas/json/service/validate"
HTTP/1.1 400 Bad Request

{
    "code": 3,
    "details": [
        {
            "@type": "type.googleapis.com/kong.admin.model.v1.ErrorDetail",
            "messages": [
                "missing properties: 'protocol', 'port', 'connect_timeout', 'read_timeout', 'write_timeout'"
            ],
            "type": "ERROR_TYPE_ENTITY"
        }
    ],
    "message": "validation error"
}
```

This doesn't match the behaviour with Kong, which would let this payload pass because of the existing schema default values:

```
$ echo '
id: 7f27869a-be49-406b-83f0-1c14becc1508
name: foo
host: example.com
path: /
' | y2j | http ":8001/schemas/services/validate"
HTTP/1.1 200 OK

{
    "message": "schema validation successful"
}
```

Koko supports schemas defaults processing via the `ProcessDefaults` method. This commit makes sure defaults are injected before schema validation is performed.