### PR TITLE
feat: add SslMode option to PostgresTLS config

### DIFF
--- a/internal/config/db.go
+++ b/internal/config/db.go
@@ -59,6 +59,9 @@ type Postgres struct {
 type PostgresTLS struct {
 	CABundlePath string `yaml:"ca_bundle_path" json:"ca_bundle_path" env:"CA_BUNDLE_PATH"`
 	Enable       bool   `yaml:"enable" json:"enable" env:"ENABLE"`
+	// SslMode should be one of the postgresql ssl modes. Default to 'verify-full'.
+	// Ref: https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-SSLMODE-STATEMENTS
+	SslMode string `yaml:"ssl_mode" json:"ssl_mode" env:"SSL_MODE"`
 }
 
 // PostgresReadReplica allows for using a read replica in addition to the
@@ -109,6 +112,7 @@ func (c *Postgres) Opts() postgres.Opts {
 		CABundleFSPath:   c.TLS.CABundlePath,
 		DBName:           c.DBName,
 		EnableTLS:        c.TLS.Enable,
+		SslMode:          c.TLS.SslMode,
 		Port:             c.Port,
 		Hostname:         c.Hostname,
 		ReadOnlyHostname: c.ReadReplica.Hostname,

--- a/internal/persistence/postgres/postgres.go
+++ b/internal/persistence/postgres/postgres.go
@@ -19,7 +19,8 @@ const (
 	insertQuery = `insert into store(key,value) values($1,$2) on conflict (key) do update set value=$2;`
 	deleteQuery = `delete from store where key=$1`
 
-	DefaultPort = 5432
+	DefaultPort       = 5432
+	defaultTLSSslMode = "verify-full"
 )
 
 type Postgres struct {
@@ -37,6 +38,7 @@ type Opts struct {
 	Password         string
 	EnableTLS        bool
 	CABundleFSPath   string
+	SslMode          string
 	SQLOpen          persistence.SQLOpenFunc
 }
 
@@ -67,7 +69,10 @@ func getDSN(opts Opts, logger *zap.Logger) (string, error) {
 	if opts.CABundleFSPath == "" {
 		return "", fmt.Errorf("postgres connection requires TLS but ca_bundle_fs_path is empty")
 	}
-	res += "sslmode=verify-full sslrootcert=" + opts.CABundleFSPath
+	if opts.SslMode == "" {
+		opts.SslMode = defaultTLSSslMode
+	}
+	res += fmt.Sprintf("sslmode=%s sslrootcert=%s", opts.SslMode, opts.CABundleFSPath)
 
 	return res, nil
 }

--- a/internal/persistence/postgres/postgres_test.go
+++ b/internal/persistence/postgres/postgres_test.go
@@ -40,6 +40,24 @@ func TestDSN(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, expectedDSN, dsn)
 	})
+	t.Run("TLS DSN with sslmode", func(t *testing.T) {
+		opt := Opts{
+			DBName:         "koko",
+			Hostname:       "localhost",
+			Port:           DefaultPort,
+			User:           "koko",
+			Password:       "koko",
+			EnableTLS:      true,
+			CABundleFSPath: "/koko-postgres-cabundle/global-bundle.pem",
+			SslMode:        "verify-ca",
+		}
+		logger := log.Logger
+		expectedDSN := "host=localhost port=5432 user=koko password=koko dbname=koko sslmode=verify-ca " +
+			"sslrootcert=/koko-postgres-cabundle/global-bundle.pem"
+		dsn, err := getDSN(opt, logger)
+		require.NoError(t, err)
+		require.Equal(t, expectedDSN, dsn)
+	})
 	t.Run("TLS DSN No CABundlePath", func(t *testing.T) {
 		opt := Opts{
 			DBName:    "koko",


### PR DESCRIPTION
Add the ability to specify the tls connection ssl mode for postgresql. 

I do not validate the user value in koko because this is already done when parsing the dsn. e.g:
```
Error: database: unable to resolve DB migration driver from the given dialect: cannot parse `host=localhost port=5432 user=koko password=xxxxx dbname=koko sslmode=invalid sslrootcert=cluster.key`: failed to configure TLS (sslmode is invalid)
```

