### PR TITLE
feat: zipkin traceid response header

### DIFF
--- a/internal/plugin/schemas/zipkin.lua
+++ b/internal/plugin/schemas/zipkin.lua
@@ -65,6 +65,7 @@ return {
           { connect_timeout = typedefs.timeout { default = 2000 } },
           { send_timeout = typedefs.timeout { default = 5000 } },
           { read_timeout = typedefs.timeout { default = 5000 } },
+          { http_response_header_for_traceid = { type = "string", default = nil } },
         },
     }, },
   },

--- a/internal/server/kong/ws/config/compat/compatibility_table.go
+++ b/internal/server/kong/ws/config/compat/compatibility_table.go
@@ -83,6 +83,7 @@ var (
 		"connect_timeout",
 		"send_timeout",
 		"read_timeout",
+		"http_response_header_for_traceid",
 	}
 	prometheus30Fields = []string{
 		"status_code_metrics",

--- a/internal/server/kong/ws/config/compat/compatibility_table.go
+++ b/internal/server/kong/ws/config/compat/compatibility_table.go
@@ -67,8 +67,8 @@ const (
 	versionsPre270      = "< 2.7.0"
 	versionsPre280      = "< 2.8.0"
 	versionsPre300      = "< 3.0.0"
+	versionsPre310      = "< 3.1.0"
 	versions300AndAbove = ">= 3.0.0"
-	versions310AndAbove = ">= 3.1.0"
 )
 
 var (
@@ -857,30 +857,16 @@ var (
 			Metadata: config.ChangeMetadata{
 				ID:       config.ChangeID("P136"),
 				Severity: config.ChangeSeverityError,
-				Description: "For the 'zipkin' plugin, " +
-					"'config.http_response_header_for_traceid' field is used " +
-					"in Kong Gateway versions >= 3.1. " +
-					"The plugin configuration has been updated to use " +
-					"'config.http_response_header_for_traceid' in the data-plane.",
-				Resolution: "Please update the configuration to use " +
-					"'config.http_response_header_for_traceid'.",
+				Description: standardPluginFieldsMessage("zipkin",
+					[]string{"http_response_header_for_traceid"},
+					"3.1", false),
+				Resolution: standardUpgradeMessage("3.1"),
 			},
-			SemverRange: versions310AndAbove,
+			SemverRange: versionsPre310,
 			Update: config.ConfigTableUpdates{
-				Name: "zipkin",
-				Type: config.Plugin,
-				FieldUpdates: []config.ConfigTableFieldCondition{
-					{
-						Field:     "http_response_header_for_traceid",
-						Condition: "http_response_header_for_traceid",
-						Updates: []config.ConfigTableFieldUpdate{
-							{
-								Field: "http_response_header_for_traceid",
-								Value: "X-B3-TraceId",
-							},
-						},
-					},
-				},
+				Name:         "zipkin",
+				Type:         config.Plugin,
+				RemoveFields: []string{"http_response_header_for_traceid"},
 			},
 		},
 	}

--- a/internal/server/kong/ws/config/compat/compatibility_table.go
+++ b/internal/server/kong/ws/config/compat/compatibility_table.go
@@ -68,6 +68,7 @@ const (
 	versionsPre280      = "< 2.8.0"
 	versionsPre300      = "< 3.0.0"
 	versions300AndAbove = ">= 3.0.0"
+	versionsPre310      = "< 3.1.0"
 )
 
 var (
@@ -83,7 +84,6 @@ var (
 		"connect_timeout",
 		"send_timeout",
 		"read_timeout",
-		"http_response_header_for_traceid",
 	}
 	prometheus30Fields = []string{
 		"status_code_metrics",
@@ -851,6 +851,22 @@ var (
 				Name:   config.Vault.String(),
 				Type:   config.Vault,
 				Remove: true,
+			},
+		},
+		{
+			Metadata: config.ChangeMetadata{
+				ID:       config.ChangeID("P136"),
+				Severity: config.ChangeSeverityError,
+				Description: standardPluginFieldsMessage("zipkin",
+					[]string{"http_response_header_for_traceid"},
+					"3.1", false),
+				Resolution: standardUpgradeMessage("3.1"),
+			},
+			SemverRange: versionsPre310,
+			Update: config.ConfigTableUpdates{
+				Name:         "zipkin",
+				Type:         config.Plugin,
+				RemoveFields: []string{"http_response_header_for_traceid"},
 			},
 		},
 	}

--- a/internal/server/kong/ws/config/compat/compatibility_table.go
+++ b/internal/server/kong/ws/config/compat/compatibility_table.go
@@ -68,7 +68,7 @@ const (
 	versionsPre280      = "< 2.8.0"
 	versionsPre300      = "< 3.0.0"
 	versions300AndAbove = ">= 3.0.0"
-	versionsPre310      = "< 3.1.0"
+	versions310AndAbove = ">= 3.1.0"
 )
 
 var (
@@ -857,16 +857,30 @@ var (
 			Metadata: config.ChangeMetadata{
 				ID:       config.ChangeID("P136"),
 				Severity: config.ChangeSeverityError,
-				Description: standardPluginFieldsMessage("zipkin",
-					[]string{"http_response_header_for_traceid"},
-					"3.1", false),
-				Resolution: standardUpgradeMessage("3.1"),
+				Description: "For the 'zipkin' plugin, " +
+					"'config.http_response_header_for_traceid' field is used " +
+					"in Kong Gateway versions >= 3.1. " +
+					"The plugin configuration has been updated to use " +
+					"'config.http_response_header_for_traceid' in the data-plane.",
+				Resolution: "Please update the configuration to use " +
+					"'config.http_response_header_for_traceid'.",
 			},
-			SemverRange: versionsPre310,
+			SemverRange: versions310AndAbove,
 			Update: config.ConfigTableUpdates{
-				Name:         "zipkin",
-				Type:         config.Plugin,
-				RemoveFields: []string{"http_response_header_for_traceid"},
+				Name: "zipkin",
+				Type: config.Plugin,
+				FieldUpdates: []config.ConfigTableFieldCondition{
+					{
+						Field:     "http_response_header_for_traceid",
+						Condition: "http_response_header_for_traceid",
+						Updates: []config.ConfigTableFieldUpdate{
+							{
+								Field: "http_response_header_for_traceid",
+								Value: "X-B3-TraceId",
+							},
+						},
+					},
+				},
 			},
 		},
 	}

--- a/internal/test/e2e/plugins.go
+++ b/internal/test/e2e/plugins.go
@@ -426,12 +426,6 @@ var VersionCompatibilityOSSPluginConfigurationTests = []VersionCompatibilityPlug
 					Value: "preserve",
 				},
 			},
-			">= 3.1.0": {
-				{
-					Field: "http_response_header_for_traceid",
-					Value: "X-B3-TraceId",
-				},
-			},
 		},
 		ConfigureForService: true,
 		ConfigureForRoute:   true,

--- a/internal/test/e2e/plugins.go
+++ b/internal/test/e2e/plugins.go
@@ -405,7 +405,8 @@ var VersionCompatibilityOSSPluginConfigurationTests = []VersionCompatibilityPlug
 	//
 	// DP < 3.0:
 	//   - remove 'http_span_name', 'connect_timeout'
-	//     'send_timeout', 'read_timeout'
+	//     'send_timeout', 'read_timeout',
+	//     'http_response_header_for_traceid'
 	{
 		Name: "zipkin",
 		Config: `{
@@ -414,7 +415,8 @@ var VersionCompatibilityOSSPluginConfigurationTests = []VersionCompatibilityPlug
 			"http_span_name": "method_path",
 			"connect_timeout": 2001,
 			"send_timeout": 2001,
-			"read_timeout": 2001
+			"read_timeout": 2001,
+			"http_response_header_for_traceid": "X-B3-TraceId"
 		}`,
 		FieldUpdateChecks: map[string][]FieldUpdateCheck{
 			"< 2.7.0": {

--- a/internal/test/e2e/plugins.go
+++ b/internal/test/e2e/plugins.go
@@ -406,8 +406,8 @@ var VersionCompatibilityOSSPluginConfigurationTests = []VersionCompatibilityPlug
 	// DP < 3.0:
 	//   - remove 'http_span_name', 'connect_timeout'
 	//     'send_timeout', 'read_timeout',
-	// DP >= 3.1:
-	//   - add 'http_response_header_for_traceid'
+	// DP < 3.1:
+	//   - remove 'http_response_header_for_traceid'
 	{
 		Name: "zipkin",
 		Config: `{
@@ -416,7 +416,8 @@ var VersionCompatibilityOSSPluginConfigurationTests = []VersionCompatibilityPlug
 			"http_span_name": "method_path",
 			"connect_timeout": 2001,
 			"send_timeout": 2001,
-			"read_timeout": 2001
+			"read_timeout": 2001,
+			"http_response_header_for_traceid": "X-B3-TraceId"
 		}`,
 		FieldUpdateChecks: map[string][]FieldUpdateCheck{
 			"< 2.7.0": {

--- a/internal/test/e2e/plugins.go
+++ b/internal/test/e2e/plugins.go
@@ -407,6 +407,8 @@ var VersionCompatibilityOSSPluginConfigurationTests = []VersionCompatibilityPlug
 	//   - remove 'http_span_name', 'connect_timeout'
 	//     'send_timeout', 'read_timeout',
 	//     'http_response_header_for_traceid'
+	// DP < 3.1:
+	//   - remove 'http_response_header_for_traceid'
 	{
 		Name: "zipkin",
 		Config: `{

--- a/internal/test/e2e/plugins.go
+++ b/internal/test/e2e/plugins.go
@@ -406,9 +406,8 @@ var VersionCompatibilityOSSPluginConfigurationTests = []VersionCompatibilityPlug
 	// DP < 3.0:
 	//   - remove 'http_span_name', 'connect_timeout'
 	//     'send_timeout', 'read_timeout',
-	//     'http_response_header_for_traceid'
-	// DP < 3.1:
-	//   - remove 'http_response_header_for_traceid'
+	// DP >= 3.1:
+	//   - add 'http_response_header_for_traceid'
 	{
 		Name: "zipkin",
 		Config: `{
@@ -417,14 +416,19 @@ var VersionCompatibilityOSSPluginConfigurationTests = []VersionCompatibilityPlug
 			"http_span_name": "method_path",
 			"connect_timeout": 2001,
 			"send_timeout": 2001,
-			"read_timeout": 2001,
-			"http_response_header_for_traceid": "X-B3-TraceId"
+			"read_timeout": 2001
 		}`,
 		FieldUpdateChecks: map[string][]FieldUpdateCheck{
 			"< 2.7.0": {
 				{
 					Field: "header_type",
 					Value: "preserve",
+				},
+			},
+			">= 3.1.0": {
+				{
+					Field: "http_response_header_for_traceid",
+					Value: "X-B3-TraceId",
 				},
 			},
 		},

--- a/internal/test/e2e/version_compatibility_test.go
+++ b/internal/test/e2e/version_compatibility_test.go
@@ -1203,3 +1203,83 @@ func TestTagsVersionCompatibility(t *testing.T) {
 		})
 	})
 }
+
+// Ensure valid field configuration for DP >= 3.1.
+func TestVersionCompatibility_Zipkin310OrNewer(t *testing.T) {
+	cleanup := run.Koko(t)
+	defer cleanup()
+
+	admin := httpexpect.WithConfig(httpexpect.Config{
+		BaseURL:  "http://localhost:3000",
+		Reporter: httpexpect.NewRequireReporter(t),
+		Printers: []httpexpect.Printer{
+			httpexpect.NewCompactPrinter(t),
+		},
+	})
+
+	tests := []vcPlugins{
+		{
+			config: `{
+				"local_service_name": "LOCAL_SERVICE_NAME",
+				"header_type": "ignore",
+				"http_span_name": "method_path",
+				"connect_timeout": 2001,
+				"send_timeout": 2001,
+				"read_timeout": 2001,
+				"http_response_header_for_traceid": "X-B3-TraceId"
+			}`,
+			expectedConfig: `{
+				"local_service_name": "LOCAL_SERVICE_NAME",
+				"header_type": "ignore",
+				"http_span_name": "method_path",
+				"connect_timeout": 2001,
+				"send_timeout": 2001,
+				"read_timeout": 2001,
+				"http_response_header_for_traceid": "X-B3-TraceId"
+			}`,
+		},
+	}
+	expectedConfig := &v1.TestingConfig{
+		Plugins: make([]*v1.Plugin, 0, len(tests)),
+	}
+
+	for _, test := range tests {
+		var config structpb.Struct
+		require.NoError(t, json.ProtoJSONUnmarshal([]byte(test.config), &config))
+
+		plugin := &v1.Plugin{
+			Id:        uuid.NewString(),
+			Name:      "zipkin",
+			Config:    &config,
+			Enabled:   wrapperspb.Bool(true),
+			Protocols: []string{"http", "https"},
+		}
+		pluginBytes, err := json.ProtoJSONMarshal(plugin)
+		require.NoError(t, err)
+		res := admin.POST("/v1/plugins").WithBytes(pluginBytes).Expect()
+		res.Status(http.StatusCreated)
+
+		var expected structpb.Struct
+		require.NoError(t, json.ProtoJSONUnmarshal([]byte(test.expectedConfig), &expected))
+		expectedConfig.Plugins = append(expectedConfig.Plugins, &v1.Plugin{
+			Id:        plugin.Id,
+			Name:      plugin.Name,
+			Config:    &expected,
+			Enabled:   plugin.Enabled,
+			Protocols: plugin.Protocols,
+		})
+	}
+
+	dpCleanup := run.KongDP(kong.GetKongConfForShared())
+	defer dpCleanup()
+	require.NoError(t, util.WaitForKong(t))
+	require.NoError(t, util.WaitForKongAdminAPI(t))
+
+	kongClient.RunWhenKong(t, ">=3.1.0")
+
+	util.WaitFunc(t, func() error {
+		err := util.EnsureConfig(expectedConfig)
+		t.Log("plugin validation failed", err)
+		return err
+	})
+}

--- a/internal/test/e2e/version_compatibility_test.go
+++ b/internal/test/e2e/version_compatibility_test.go
@@ -211,7 +211,7 @@ func TestVersionCompatibility_PluginFieldUpdates(t *testing.T) {
 	for _, plugin := range expectedPluginsMap {
 		var config structpb.Struct
 		if len(plugin.Config) > 0 {
-			require.NoError(t, json.ProtoJSONUnmarshal([]byte(plugin.Config), &config))
+			require.NoError(t, json.ProtoJSONUnmarshal([]byte(plugin.Config), &config), plugin)
 		}
 
 		p := &v1.Plugin{


### PR DESCRIPTION
Adds `http_response_header_for_traceid`for zipkin.

See https://github.com/Kong/kong/pull/9173