### PR TITLE
refactor: use pgxpool.Pool instead of database/sql for postgresql

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/hbagdi/gang v0.1.0
 	github.com/ilyakaznacheev/cleanenv v1.4.1
 	github.com/imdario/mergo v0.3.13
+	github.com/jackc/pgconn v1.13.0
 	github.com/jackc/pgx/v4 v4.17.2
 	github.com/jeremywohl/flatten v1.0.1
 	github.com/kong/go-kong v0.33.0
@@ -87,12 +88,12 @@ require (
 	github.com/imkira/go-interpol v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.1 // indirect
 	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
-	github.com/jackc/pgconn v1.13.0 // indirect
 	github.com/jackc/pgio v1.0.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgproto3/v2 v2.3.1 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20200714003250-2b9c44734f2b // indirect
 	github.com/jackc/pgtype v1.12.0 // indirect
+	github.com/jackc/puddle v1.3.0 // indirect
 	github.com/jdxcode/netrc v0.0.0-20210204082910-926c7f70242a // indirect
 	github.com/joho/godotenv v1.4.0 // indirect
 	github.com/klauspost/compress v1.15.11 // indirect

--- a/go.sum
+++ b/go.sum
@@ -809,6 +809,7 @@ github.com/jackc/puddle v0.0.0-20190608224051-11cab39313c9/go.mod h1:m4B5Dj62Y0f
 github.com/jackc/puddle v1.1.0/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.1.1/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.1.3/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
+github.com/jackc/puddle v1.3.0 h1:eHK/5clGOatcjX3oWGBO/MpxpbHzSwud5EWTSCI+MX0=
 github.com/jackc/puddle v1.3.0/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jdxcode/netrc v0.0.0-20210204082910-926c7f70242a h1:d4+I1YEKVmWZrgkt6jpXBnLgV2ZjO0YxEtLDdfIZfH4=
 github.com/jdxcode/netrc v0.0.0-20210204082910-926c7f70242a/go.mod h1:Zi/ZFkEqFHTm7qkjyNJjaWH4LQA9LQhGJyF0lTYGpxw=

--- a/internal/config/testdata/good-0.yaml
+++ b/internal/config/testdata/good-0.yaml
@@ -20,6 +20,13 @@ database:
       ca_bundle_path: "/tmp/foo.crt"
     read_replica:
       hostname: "read-localhost"
+    pool:
+      name: pgx
+      max_connections: 30
+      min_connections: 5
+      max_connection_idle_time: 10m
+      max_connection_lifetime: 20m
+      health_check_period: 30s
 metrics:
   client_type: "noop"
   prometheus:

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/kong/koko/internal/persistence"
 	"github.com/kong/koko/internal/persistence/mysql"
 	"github.com/kong/koko/internal/persistence/postgres"
 	"github.com/kong/koko/internal/persistence/sqlite"
@@ -41,7 +42,11 @@ func TestNewSQLDBFromConfig(t *testing.T) {
 
 	t.Run("Postgres", func(t *testing.T) {
 		config.Dialect = DialectPostgres
-		config.Postgres = postgres.Opts{SQLOpen: noOpOpenFunc}
+		poolOpts := postgres.PoolOpts{
+			MaxConns:          persistence.DefaultMaxConn,
+			HealthCheckPeriod: persistence.DefaultHealthCheckPeriod,
+		}
+		config.Postgres = postgres.Opts{SQLOpen: noOpOpenFunc, Pool: poolOpts}
 		_, err := NewSQLDBFromConfig(config)
 		assert.NoError(t, err)
 	})

--- a/internal/persistence/driver.go
+++ b/internal/persistence/driver.go
@@ -7,10 +7,13 @@ import (
 
 // Various default settings used for non-SQLite DB drivers.
 const (
-	DefaultDialTimeout     = 15 * time.Second
-	DefaultMaxConn         = 50
-	DefaultMaxConnLifetime = time.Hour
-	DefaultMaxIdleConn     = 20
+	DefaultDialTimeout       = 15 * time.Second
+	DefaultMaxConn           = 50
+	DefaultMinConn           = 2
+	DefaultMaxConnLifetime   = time.Hour
+	DefaultMaxConnIdleTime   = time.Hour
+	DefaultMaxIdleConn       = 20
+	DefaultHealthCheckPeriod = time.Minute
 )
 
 // SQLOpenFunc defines a function that can instantiate a sql.DB instance from the given DSN.

--- a/internal/persistence/postgres/options.go
+++ b/internal/persistence/postgres/options.go
@@ -53,6 +53,9 @@ type Opts struct {
 	// information about connection parameters.
 	// See: https://www.postgresql.org/docs/current/runtime-config.html for more information about runtime parameters.
 	Params map[string]string
+
+	// Pool defines configuration for connections pooling.
+	Pool PoolOpts
 }
 
 // Validate ensures the provided Postgres options are a valid configuration.

--- a/internal/persistence/postgres/pool.go
+++ b/internal/persistence/postgres/pool.go
@@ -1,0 +1,146 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgconn"
+	"github.com/jackc/pgx/v4"
+	"github.com/jackc/pgx/v4/pgxpool"
+	"go.uber.org/zap"
+)
+
+var pools = map[string]PoolOpenFunc{}
+
+// Pool is the interface of the pgxpool.Pool type, used by the postgres
+// persistence layer to query the database. A custom pool type can be
+// registered using `RegisterPool` if it implements this interface.
+type Pool interface {
+	Close()
+	Acquire(ctx context.Context) (*pgxpool.Conn, error)
+	AcquireFunc(ctx context.Context, f func(*pgxpool.Conn) error) error
+	AcquireAllIdle(ctx context.Context) []*pgxpool.Conn
+	Config() *pgxpool.Config
+	Stat() *pgxpool.Stat
+	Exec(ctx context.Context, sql string, arguments ...interface{}) (pgconn.CommandTag, error)
+	Query(ctx context.Context, sql string, args ...interface{}) (pgx.Rows, error)
+	QueryRow(ctx context.Context, sql string, args ...interface{}) pgx.Row
+	QueryFunc(ctx context.Context, sql string, args []interface{}, scans []interface{},
+		f func(pgx.QueryFuncRow) error) (pgconn.CommandTag, error)
+	SendBatch(ctx context.Context, b *pgx.Batch) pgx.BatchResults
+	Begin(ctx context.Context) (pgx.Tx, error)
+	BeginTx(ctx context.Context, txOptions pgx.TxOptions) (pgx.Tx, error)
+	BeginFunc(ctx context.Context, f func(pgx.Tx) error) error
+	BeginTxFunc(ctx context.Context, txOptions pgx.TxOptions, f func(pgx.Tx) error) error
+	CopyFrom(ctx context.Context, tableName pgx.Identifier, columnNames []string, rowSrc pgx.CopyFromSource) (int64, error)
+	Ping(ctx context.Context) error
+}
+
+// PoolOpenFunc defines a function that can instantiate a Pool instance with the given options.
+type PoolOpenFunc func(opts Opts, logger *zap.Logger) (Pool, error)
+
+// PoolOpts defines configuration for connections pooling.
+type PoolOpts struct {
+	// The name of the postgres pool implementation to use.
+	// By default, only `pgx` is available.
+	Name string
+
+	// MaxConns is the maximum size of the pool. Default to `persistence.DefaultMaxConn`.
+	MaxConns int
+
+	// MinConns is the minimum size of the pool. Default to `persistence.DefaultMinConn`.
+	MinConns int
+
+	// MaxConnLifetime is the duration since creation after which a connection will
+	// be automatically closed. Default to `persistence.DefaultMaxConnLifetime`.
+	MaxConnLifetime time.Duration
+
+	// MaxConnIdleTime is the duration after which an idle connection will be automatically
+	// closed by the health check. Default to `persistence.DefaultMaxConnIdleTime`.
+	MaxConnIdleTime time.Duration
+
+	// HealthCheckPeriod is the duration between checks of the health of
+	// idle connections. Default to `persistence.DefaultHealthCheckPeriod`.
+	HealthCheckPeriod time.Duration
+
+	// ReadOnly indicates the pool will be used for read only operations.
+	ReadOnly bool
+}
+
+// Validate ensures the provided Postgres.Pool options are a valid configuration.
+func (opts *PoolOpts) Validate() error {
+	// by validating these values, we avoid panics from pgxpool at connection
+	if opts.MaxConns < 1 {
+		return fmt.Errorf("invalid Pool.MaxConns value: '%d', should be greater than 0", opts.MaxConns)
+	}
+
+	if opts.HealthCheckPeriod < 1 {
+		return fmt.Errorf("invalid Pool.HealthCheckPeriod value: '%d', should be a positive duration", opts.HealthCheckPeriod)
+	}
+
+	return nil
+}
+
+func newPostgresPool(opts Opts, logger *zap.Logger) (Pool, error) {
+	if err := opts.Pool.Validate(); err != nil {
+		return nil, err
+	}
+
+	if poolOpenFunc, present := pools[opts.Pool.Name]; present {
+		logger.Info(fmt.Sprintf("using Postgres %s pool", opts.Pool.Name))
+		return poolOpenFunc(opts, logger)
+	}
+
+	return nil, fmt.Errorf("invalid postgres pool '%s'", opts.Pool.Name)
+}
+
+// NewPgxPoolConfig creates and configure a new pgxpool.Config with the given options.
+func NewPgxPoolConfig(opts Opts, logger *zap.Logger) (*pgxpool.Config, error) {
+	dsn, err := opts.DSN(logger)
+	if err != nil {
+		return nil, err
+	}
+
+	config, err := pgxpool.ParseConfig(dsn)
+	if err != nil {
+		return nil, err
+	}
+
+	config.MaxConns = int32(opts.Pool.MaxConns)
+	config.MinConns = int32(opts.Pool.MinConns)
+	config.MaxConnLifetime = opts.Pool.MaxConnLifetime
+	config.MaxConnIdleTime = opts.Pool.MaxConnIdleTime
+	config.HealthCheckPeriod = opts.Pool.HealthCheckPeriod
+
+	return config, nil
+}
+
+func newPgxPool(opts Opts, logger *zap.Logger) (Pool, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second) //nolint:gomnd
+	defer cancel()
+
+	pgxPoolConfig, err := NewPgxPoolConfig(opts, logger)
+	if err != nil {
+		return nil, err
+	}
+
+	return pgxpool.ConnectConfig(ctx, pgxPoolConfig)
+}
+
+// RegisterPool adds a `Pool` implementation to the postgres configuration.
+// It is not thread-safe.
+func RegisterPool(poolName string, poolOpenFunc PoolOpenFunc) error {
+	if _, present := pools[poolName]; present {
+		return fmt.Errorf("pool name '%s' already exists", poolName)
+	}
+	pools[poolName] = poolOpenFunc
+
+	return nil
+}
+
+func init() {
+	if err := RegisterPool(DefaultPool, newPgxPool); err != nil {
+		panic(err)
+	}
+}

--- a/internal/persistence/postgres/pool_test.go
+++ b/internal/persistence/postgres/pool_test.go
@@ -1,0 +1,123 @@
+package postgres
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/kong/koko/internal/log"
+	"github.com/kong/koko/internal/persistence"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestPoolOpts(t *testing.T) {
+	t.Run("pool options are applied to the pgxpool.Config", func(t *testing.T) {
+		d := 42 * time.Second
+		opt := Opts{
+			DBName:   "koko",
+			Hostname: "localhost",
+			Port:     DefaultPort,
+			User:     "koko",
+			Password: "koko",
+			Pool: PoolOpts{
+				MaxConns:          42,
+				MinConns:          42,
+				MaxConnLifetime:   d,
+				MaxConnIdleTime:   d,
+				HealthCheckPeriod: d,
+			},
+		}
+		logger := log.Logger
+		pgxPoolConfig, err := NewPgxPoolConfig(opt, logger)
+		require.NoError(t, err)
+		require.Equal(t, int32(42), pgxPoolConfig.MaxConns)
+		require.Equal(t, int32(42), pgxPoolConfig.MinConns)
+		require.Equal(t, d, pgxPoolConfig.MaxConnLifetime)
+		require.Equal(t, d, pgxPoolConfig.MaxConnIdleTime)
+		require.Equal(t, d, pgxPoolConfig.HealthCheckPeriod)
+	})
+	t.Run("pool options are validated", func(t *testing.T) {
+		d := 10 * time.Second
+		poolOpts := []PoolOpts{
+			{
+				MaxConns:          0,
+				HealthCheckPeriod: d,
+			},
+			{
+				MaxConns:          -1,
+				HealthCheckPeriod: d,
+			},
+			{
+				MaxConns:          10,
+				HealthCheckPeriod: 0,
+			},
+			{
+				MaxConns:          10,
+				HealthCheckPeriod: -1,
+			},
+		}
+		for _, poolOpt := range poolOpts {
+			err := poolOpt.Validate()
+			require.Error(t, err)
+		}
+	})
+}
+
+func TestPoolRegistration(t *testing.T) {
+	customPoolOpenFunc := func(opts Opts, logger *zap.Logger) (Pool, error) {
+		return nil, fmt.Errorf("custom pool open func")
+	}
+	t.Run("default pool is registered", func(t *testing.T) {
+		defaultPoolOpenFunc, present := pools[DefaultPool]
+		require.NotNil(t, defaultPoolOpenFunc)
+		require.True(t, present)
+	})
+	t.Run("custom pool can be registered", func(t *testing.T) {
+		err := RegisterPool("customPool", customPoolOpenFunc)
+		require.NoError(t, err)
+	})
+	t.Run("custom pool can be set using PoolOpts.Name", func(t *testing.T) {
+		err := RegisterPool("customPool2", customPoolOpenFunc)
+		require.NoError(t, err)
+		opt := Opts{
+			DBName:   "koko",
+			Hostname: "localhost",
+			Port:     DefaultPort,
+			User:     "koko",
+			Password: "koko",
+			Pool: PoolOpts{
+				Name:              "customPool2",
+				MaxConns:          persistence.DefaultMaxConn,
+				HealthCheckPeriod: persistence.DefaultHealthCheckPeriod,
+			},
+		}
+		logger := log.Logger
+		_, err = newPostgresPool(opt, logger)
+		require.ErrorContains(t, err, "custom pool open func")
+	})
+	t.Run("invalid custom pool return error", func(t *testing.T) {
+		opt := Opts{
+			DBName:   "koko",
+			Hostname: "localhost",
+			Port:     DefaultPort,
+			User:     "koko",
+			Password: "koko",
+			Pool: PoolOpts{
+				Name:              "invalidPool",
+				MaxConns:          persistence.DefaultMaxConn,
+				HealthCheckPeriod: persistence.DefaultHealthCheckPeriod,
+			},
+		}
+		logger := log.Logger
+		_, err := newPostgresPool(opt, logger)
+		require.ErrorContains(t, err, "invalid postgres pool")
+	})
+	t.Run("pool name is unique and cannot be registered twice", func(t *testing.T) {
+		err := RegisterPool("myOtherPool", customPoolOpenFunc)
+		require.NoError(t, err)
+		err = RegisterPool("myOtherPool", customPoolOpenFunc)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "already exists")
+	})
+}

--- a/internal/persistence/postgres/tx.go
+++ b/internal/persistence/postgres/tx.go
@@ -1,0 +1,42 @@
+package postgres
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v4"
+	"github.com/kong/koko/internal/persistence"
+)
+
+type postgresTx struct {
+	ctx   context.Context
+	tx    pgx.Tx
+	query postgresQuery
+}
+
+func (t *postgresTx) Commit() error {
+	return t.tx.Commit(t.ctx)
+}
+
+func (t *postgresTx) Rollback() error {
+	return t.tx.Rollback(t.ctx)
+}
+
+func (t *postgresTx) Get(ctx context.Context, key string) ([]byte, error) {
+	return t.query.Get(ctx, key)
+}
+
+func (t *postgresTx) Put(ctx context.Context, key string, value []byte) error {
+	return t.query.Put(ctx, key, value)
+}
+
+func (t *postgresTx) Delete(ctx context.Context, key string) error {
+	return t.query.Delete(ctx, key)
+}
+
+func (t *postgresTx) List(
+	ctx context.Context,
+	prefix string,
+	opts *persistence.ListOpts,
+) (persistence.ListResult, error) {
+	return t.query.List(ctx, prefix, opts)
+}

--- a/internal/test/util/db.go
+++ b/internal/test/util/db.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ilyakaznacheev/cleanenv"
 	"github.com/kong/koko/internal/config"
 	"github.com/kong/koko/internal/db"
+	"github.com/kong/koko/internal/persistence"
 	"github.com/kong/koko/internal/persistence/postgres"
 )
 
@@ -74,6 +75,14 @@ func setDBConfig(conf *config.Database) error {
 				Port:     postgres.DefaultPort,
 				User:     "koko",
 				Password: "koko",
+				Pool: config.PostgresPool{
+					Name:              postgres.DefaultPool,
+					MaxConns:          persistence.DefaultMaxConn,
+					MinConns:          persistence.DefaultMinConn,
+					MaxConnLifetime:   persistence.DefaultMaxConnLifetime,
+					MaxConnIdleTime:   persistence.DefaultMaxConnIdleTime,
+					HealthCheckPeriod: persistence.DefaultHealthCheckPeriod,
+				},
 			}
 		}
 	default:


### PR DESCRIPTION
This PR is a refactor of the postgres persistence layer. Changes:

* Use the `pgxpool.Pool` interface to execute query instead of the built-in `database/sql`
* Add basic pooling options to the postgres config options.
* Make the postgres Pool plugable under the hood.