### PR TITLE
fix: updating route resource to accept wildcard hostnames

### DIFF
--- a/internal/gen/jsonschema/schemas/route.json
+++ b/internal/gen/jsonschema/schemas/route.json
@@ -77,9 +77,9 @@
     "hosts": {
       "items": {
         "maxLength": 256,
-        "pattern": "^[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?(.[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?)*$",
+        "pattern": "^(\\*\\.)?[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?(.[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?)*$",
         "type": "string",
-        "description": "must be a valid hostname"
+        "description": "must be a valid hostname with a wildcard prefix '*' or without"
       },
       "maxItems": 16,
       "type": "array"

--- a/internal/resource/route.go
+++ b/internal/resource/route.go
@@ -230,7 +230,7 @@ func init() {
 			},
 			"hosts": {
 				Type:     "array",
-				Items:    typedefs.Host,
+				Items:    typedefs.WilcardHost,
 				MaxItems: maxMatchElements,
 			},
 			"paths": {

--- a/internal/resource/route_test.go
+++ b/internal/resource/route_test.go
@@ -182,7 +182,7 @@ func TestRoute_Validate(t *testing.T) {
 					Type:  model.ErrorType_ERROR_TYPE_FIELD,
 					Field: "hosts[0]",
 					Messages: []string{
-						"must be a valid hostname",
+						"must be a valid hostname with a wildcard prefix '*' or without",
 					},
 				},
 			},
@@ -1308,6 +1308,14 @@ func TestRoute_Validate(t *testing.T) {
 						"must not contain a port: 'sni:8080'",
 					},
 				},
+			},
+		},
+		{
+			name: "wildcard host doesn't throw an error",
+			Route: func() Route {
+				r := goodRoute()
+				r.Route.Hosts = []string{"*.example.com"}
+				return r
 			},
 		},
 	}

--- a/internal/server/admin/route_test.go
+++ b/internal/server/admin/route_test.go
@@ -44,6 +44,16 @@ func TestRouteCreate(t *testing.T) {
 		body := res.JSON().Path("$.item").Object()
 		validateGoodRoute(body)
 	})
+	t.Run("route with wildcard host is valid", func(t *testing.T) {
+		route := goodRoute()
+		route.Name = "with-wildcard-host"
+		route.Hosts = []string{"*.example.com"}
+		res := c.POST("/v1/routes").WithJSON(route).Expect()
+		res.Status(http.StatusCreated)
+		body := res.JSON().Path("$.item").Object()
+		body.Value("hosts").Array().Equal([]string{"*.example.com"})
+		validateGoodRoute(body)
+	})
 	t.Run("creating a route with ws protocol fails", func(t *testing.T) {
 		util.SkipTestIfEnterpriseTesting(t, true)
 		route := goodRoute()


### PR DESCRIPTION
This change alters the `Route` entity to allow the `Hosts` field to take in wildcard hostnames, e.g.: `*.example.com`.