### PR TITLE
fix: Disable Change Tracking for Zipkin TraceID Header

### DIFF
--- a/internal/server/kong/ws/config/compat/compatibility_table.go
+++ b/internal/server/kong/ws/config/compat/compatibility_table.go
@@ -867,6 +867,11 @@ var (
 				Name:         "zipkin",
 				Type:         config.Plugin,
 				RemoveFields: []string{"http_response_header_for_traceid"},
+				DisableChangeTracking: func(rawJSON string) bool {
+					plugin := gjson.Parse(rawJSON)
+					traceHeader := plugin.Get("config.http_response_header_for_traceid")
+					return traceHeader.Exists() && traceHeader.Type == gjson.Null
+				},
 			},
 		},
 	}

--- a/internal/server/kong/ws/config/compat/compatibility_table_test.go
+++ b/internal/server/kong/ws/config/compat/compatibility_table_test.go
@@ -925,6 +925,7 @@ func TestDisableChangeTracking(t *testing.T) {
 					"connect_timeout": 2000,
 					"read_timeout": 5000,
 					"send_timeout": 5000,
+					"http_response_header_for_traceid": null
 				}
 			}
 		]
@@ -1138,6 +1139,53 @@ func TestDisableChangeTracking(t *testing.T) {
 				ChangeDetails: []config.ChangeDetail{
 					{
 						ID: "P116",
+						Resources: []config.ResourceInfo{
+							{
+								Type: "plugin",
+								ID:   "759c0d3a-bc3d-4ccc-8d4d-f92de95c1f1a",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "[zipkin] change is emitted with non-default value for" +
+				" http_response_header_for_traceid",
+			uncompressedPayload: `
+{
+	"config_table": {
+		"plugins": [
+			{
+				"id": "759c0d3a-bc3d-4ccc-8d4d-f92de95c1f1a",
+				"name": "zipkin",
+				"config": {
+					"http_response_header_for_traceid": "X-B3-TraceId"
+				}
+			}
+		]
+	}
+}
+`,
+			dataPlaneVersion: "2.7.0",
+			expectedPayload: `
+{
+	"config_table": {
+		"plugins": [
+			{
+				"id": "759c0d3a-bc3d-4ccc-8d4d-f92de95c1f1a",
+				"name": "zipkin",
+				"config": {
+				}
+			}
+		]
+	}
+}
+`,
+			expectedChanges: config.TrackedChanges{
+				ChangeDetails: []config.ChangeDetail{
+					{
+						ID: "P136",
 						Resources: []config.ResourceInfo{
 							{
 								Type: "plugin",


### PR DESCRIPTION
Adds a check on config.http_response_header_for_traceid for the zipkin plugin. Change tracking is conditionally ignored when this field is set to the default value (nil).