### PR TITLE
tests: increase integration test timeout to 15m

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ test-race:
 
 .PHONY: test-integration
 test-integration:
-	go test -tags=testsetup,integration -race -count 1 -p 1 ./internal/test/...
+	go test -tags=testsetup,integration -timeout 15m -race -count 1 -p 1 ./internal/test/...
 
 .PHONY: gen
 gen:


### PR DESCRIPTION
v3.0 is a little slower so we need to increase the timeout on e2e tests to avoid timeout failures.