### PR TITLE
feat: allowing persistence store to list foreign objects

### DIFF
--- a/internal/persistence/mysql/mysql.go
+++ b/internal/persistence/mysql/mysql.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	sq "github.com/Masterminds/squirrel"
@@ -231,6 +232,9 @@ func (t *mysqlQuery) List(
 ) (persistence.ListResult, error) {
 	ctx, cancel := context.WithTimeout(ctx, t.queryTimeout)
 	defer cancel()
+
+	// Replacing any wildcard operators with the proper wildcard operator for MySQL.
+	prefix = strings.ReplaceAll(prefix, persistence.WildcardOperator, "%")
 
 	query := sq.StatementBuilder.
 		Select("`key`", "value", "COUNT(*) OVER() AS full_count").

--- a/internal/persistence/postgres/postgres.go
+++ b/internal/persistence/postgres/postgres.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 	"time"
 
 	sq "github.com/Masterminds/squirrel"
@@ -200,6 +201,9 @@ func (t *postgresQuery) List(
 	ctx, cancel := context.WithTimeout(ctx, t.queryTimeout)
 	defer cancel()
 	kvlist := make([]persistence.KVResult, 0, opts.Limit)
+
+	// Replacing any wildcard operators with the proper wildcard operator for Postgres.
+	prefix = strings.ReplaceAll(prefix, persistence.WildcardOperator, "%")
 
 	query := sq.StatementBuilder.
 		PlaceholderFormat(sq.Dollar).

--- a/internal/persistence/sql.go
+++ b/internal/persistence/sql.go
@@ -4,6 +4,9 @@ import (
 	"database/sql"
 )
 
+// WildcardOperator is used to represent a SQL wildcard (`%`) within a key.
+const WildcardOperator = "\u0000"
+
 // SQLPersister should be implemented for all persistence stores that implement an underlining sql.DB driver.
 type SQLPersister interface {
 	// Driver returns the relevant Golang SQL driver used to connect to the database.

--- a/internal/persistence/sqlite/sqlite.go
+++ b/internal/persistence/sqlite/sqlite.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 	"time"
 
 	sq "github.com/Masterminds/squirrel"
@@ -214,6 +215,9 @@ func (t *sqliteQuery) Delete(ctx context.Context, key string) error {
 func (t *sqliteQuery) List(ctx context.Context, prefix string,
 	opts *persistence.ListOpts,
 ) (persistence.ListResult, error) {
+	// Replacing any wildcard operators with the proper wildcard operator for SQLLite.
+	prefix = strings.ReplaceAll(prefix, persistence.WildcardOperator, "*")
+
 	query := sq.StatementBuilder.
 		PlaceholderFormat(sq.Dollar).
 		Select("s.key", "s.value", "COUNT(*) OVER() AS full_count").

--- a/internal/store/opts.go
+++ b/internal/store/opts.go
@@ -160,7 +160,7 @@ func ListFor(typ model.Type, id string) ListOptsFunc {
 //     service: {id: service-1}
 //   - id: route-3
 //
-// When calling `ListFor(resource.TypeRoute, "route-1")` with
+// When calling `ListReverseFor(resource.TypeRoute, "route-1")` with
 // `resource.NewList(resource.TypeService)`.
 //
 // Then this would return the service with ID `service-1`.

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -443,8 +444,20 @@ func (s *ObjectStore) referencedList(ctx context.Context, list model.ObjectList,
 		if err != nil {
 			return err
 		}
-		err = s.readByTypeID(ctx, s.store, typ, key[keyPrefixLen:], object)
-		if err != nil {
+
+		// When `opt.ReferenceReverseLookup` is not true, we're extracting <id> from the below key:
+		// `c/.../ix/f/<typ>/<opt.ReferenceID>/<opt.ReferenceType>/<id>`
+		//
+		// When it is true, we're extracting the <id> from the below key:
+		// `c/.../ix/f/<typ>/<id>/<opt.ReferenceType>/<opt.ReferenceID>`
+		id := key[keyPrefixLen:]
+		if opt.ReferenceReverseLookup {
+			startIdx := strings.Index(keyPrefix, persistence.WildcardOperator)
+			endIdx := strings.Index(key[startIdx:], "/")
+			id = key[startIdx : startIdx+endIdx]
+		}
+
+		if err := s.readByTypeID(ctx, s.store, typ, id, object); err != nil {
 			return err
 		}
 		list.Add(object)
@@ -458,8 +471,13 @@ func (s *ObjectStore) referencedList(ctx context.Context, list model.ObjectList,
 }
 
 func (s *ObjectStore) referencedListKey(typ model.Type, opt *ListOpts) string {
-	return s.clusterKey(fmt.Sprintf("ix/f/%s/%s/%s/",
-		opt.ReferenceType, opt.ReferenceID, typ))
+	parts := []string{string(opt.ReferenceType), opt.ReferenceID, string(typ)}
+	suffix := "/"
+	if opt.ReferenceReverseLookup {
+		parts = []string{string(typ), persistence.WildcardOperator, string(opt.ReferenceType), opt.ReferenceID}
+		suffix = ""
+	}
+	return s.clusterKey(strings.Join(append([]string{"ix", "f"}, parts...), "/")) + suffix
 }
 
 func (s *ObjectStore) listKey(typ model.Type) string {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -453,8 +453,10 @@ func (s *ObjectStore) referencedList(ctx context.Context, list model.ObjectList,
 		id := key[keyPrefixLen:]
 		if opt.ReferenceReverseLookup {
 			startIdx := strings.Index(keyPrefix, persistence.WildcardOperator)
-			endIdx := strings.Index(key[startIdx:], "/")
-			id = key[startIdx : startIdx+endIdx]
+			if startIdx < 0 {
+				return errors.New("unable to find wildcard operator in key prefix")
+			}
+			id, _, _ = strings.Cut(key[startIdx:], "/")
 		}
 
 		if err := s.readByTypeID(ctx, s.store, typ, id, object); err != nil {


### PR DESCRIPTION
This introduces a change to the persistence store that allows callers to list the foriegn resources themselves. Currently, a `ListFor()` call exists that allows listing resource(s) that have the associated foreign key index, although listing the other way around was not previously supported.