### PR TITLE
fix: validate object indexes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	github.com/stretchr/testify v1.8.1
 	github.com/tidwall/gjson v1.14.4
 	github.com/tidwall/sjson v1.2.5
+	github.com/yalp/jsonpath v0.0.0-20180802001716-5cc68e5049a0
 	github.com/yuin/gopher-lua v0.0.0-20210529063254-f4c35e4016d9
 	go.uber.org/atomic v1.10.0
 	go.uber.org/zap v1.24.0
@@ -139,7 +140,6 @@ require (
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
-	github.com/yalp/jsonpath v0.0.0-20180802001716-5cc68e5049a0 // indirect
 	github.com/yudai/gojsondiff v1.0.0 // indirect
 	github.com/yudai/golcs v0.0.0-20170316035057-ecda9a501e82 // indirect
 	github.com/yuin/gluare v0.0.0-20170607022532-d7c94f1a80ed // indirect

--- a/internal/model/object_test.go
+++ b/internal/model/object_test.go
@@ -1,6 +1,10 @@
 package model
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
 
 func TestMultiValueIndex(t *testing.T) {
 	type args struct {
@@ -45,6 +49,165 @@ func TestMultiValueIndex(t *testing.T) {
 			if got := MultiValueIndex(tt.args.values...); got != tt.want {
 				t.Errorf("MultiValueIndex() = %v, want %v", got, tt.want)
 			}
+		})
+	}
+}
+
+func TestIndex_Validate(t *testing.T) {
+	tests := []struct {
+		name          string
+		index         Index
+		expectedError string
+	}{
+		{
+			name: "invalid name",
+			index: Index{
+				Type:  IndexUnique,
+				Value: "something",
+			},
+			expectedError: "index name is not set",
+		},
+		{
+			name: "invalid type",
+			index: Index{
+				Name:  "something",
+				Value: "something",
+			},
+			expectedError: "index type is not set",
+		},
+		{
+			name: "invalid value",
+			index: Index{
+				Name: "something",
+				Type: IndexUnique,
+			},
+			expectedError: "index value is not set",
+		},
+		{
+			name: "invalid field name: prefix provided",
+			index: Index{
+				FieldName: "$.something",
+				Name:      "something",
+				Type:      IndexUnique,
+				Value:     "something",
+			},
+			expectedError: `must not include JSONPath prefix ("$.") in field name`,
+		},
+		{
+			name: "invalid field name: invalid JSONPath",
+			index: Index{
+				FieldName: "something.",
+				Name:      "something",
+				Type:      IndexUnique,
+				Value:     "something",
+			},
+			expectedError: `invalid JSONPath field name: expected JSON child identifier after '.' at 13`,
+		},
+		{
+			name: "invalid foreign type: not provided",
+			index: Index{
+				Name:  "something",
+				Type:  IndexForeign,
+				Value: "something",
+			},
+			expectedError: `index foreign type is not set`,
+		},
+		{
+			name: "valid index object",
+			index: Index{
+				Name:        "something",
+				Type:        IndexForeign,
+				Value:       "something",
+				ForeignType: "something",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.index.Validate()
+			if tt.expectedError != "" {
+				assert.EqualError(t, err, tt.expectedError)
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestIndexes_Validate(t *testing.T) {
+	tests := []struct {
+		name          string
+		indexes       Indexes
+		expectedError string
+	}{
+		{
+			name: "ensure regular validation executes: without name",
+			indexes: Indexes{{
+				Type:  IndexUnique,
+				Value: "something",
+			}},
+			expectedError: "invalid index in list: index name is not set",
+		},
+		{
+			name: "ensure regular validation executes: with name",
+			indexes: Indexes{{
+				Name: "something",
+				Type: IndexUnique,
+			}},
+			expectedError: `invalid index (name = "something") in list: index value is not set`,
+		},
+		{
+			name: "ensure regular validation executes: with field name",
+			indexes: Indexes{{
+				FieldName: "something",
+				Type:      IndexUnique,
+			}},
+			expectedError: `invalid index (field_name = "something") in list: index value is not set`,
+		},
+		{
+			name: "ensure no duplicates",
+			indexes: Indexes{
+				{
+					ForeignType: "something",
+					Name:        "something",
+					Type:        IndexForeign,
+					Value:       "something",
+				},
+				{
+					ForeignType: "something",
+					Name:        "something",
+					Type:        IndexForeign,
+					Value:       "something",
+				},
+			},
+			expectedError: `invalid index (name = "something") in list: duplicate index contents`,
+		},
+		{
+			name: "valid indexes",
+			indexes: Indexes{
+				{
+					ForeignType: "something",
+					Name:        "something",
+					Type:        IndexForeign,
+					Value:       "something",
+				},
+				{
+					ForeignType: "something",
+					Name:        "something",
+					Type:        IndexForeign,
+					Value:       "another thing",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.indexes.Validate()
+			if tt.expectedError != "" {
+				assert.EqualError(t, err, tt.expectedError)
+				return
+			}
+			assert.NoError(t, err)
 		})
 	}
 }

--- a/internal/resource/ca_certificate.go
+++ b/internal/resource/ca_certificate.go
@@ -149,6 +149,10 @@ func (r CACertificate) ProcessDefaults(ctx context.Context) error {
 }
 
 func (r CACertificate) Indexes() []model.Index {
+	if r.CACertificate.CertDigest == "" {
+		return nil
+	}
+
 	return []model.Index{
 		{
 			Name:      "cert_digest",

--- a/internal/resource/route.go
+++ b/internal/resource/route.go
@@ -75,13 +75,14 @@ func (r Route) Resource() model.Resource {
 func (r Route) SetResource(pr model.Resource) error { return model.SetResource(r, pr) }
 
 func (r Route) Indexes() []model.Index {
-	res := []model.Index{
-		{
+	res := make([]model.Index, 0)
+	if r.Route.Name != "" {
+		res = append(res, model.Index{
 			Name:      "name",
 			Type:      model.IndexUnique,
 			Value:     r.Route.Name,
 			FieldName: "name",
-		},
+		})
 	}
 	if r.Route.Service != nil {
 		res = append(res, model.Index{

--- a/internal/resource/service.go
+++ b/internal/resource/service.go
@@ -104,13 +104,14 @@ func (r Service) ProcessDefaults(ctx context.Context) error {
 }
 
 func (r Service) Indexes() []model.Index {
-	indexes := []model.Index{
-		{
+	indexes := make([]model.Index, 0)
+	if r.Service.Name != "" {
+		indexes = append(indexes, model.Index{
 			Name:      "name",
 			Type:      model.IndexUnique,
 			Value:     r.Service.Name,
 			FieldName: "name",
-		},
+		})
 	}
 	for _, certID := range r.Service.CaCertificates {
 		indexes = append(indexes, model.Index{

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -262,17 +262,16 @@ func (s *ObjectStore) clock() string {
 }
 
 func preProcess(ctx context.Context, object model.Object) error {
-	err := object.ProcessDefaults(ctx)
-	if err != nil {
+	if err := object.ProcessDefaults(ctx); err != nil {
 		return err
 	}
 	addTS(object.Resource())
 
-	err = object.Validate(ctx)
-	if err != nil {
+	if err := object.Validate(ctx); err != nil {
 		return err
 	}
-	return nil
+
+	return model.Indexes(object.Indexes()).Validate()
 }
 
 func (s *ObjectStore) Read(ctx context.Context, object model.Object,


### PR DESCRIPTION
This introduces the ability to validate any indexes at runtime during the creation/updation process. There were some issues where empty indexes were being improperly provided and were being ignored by the `ObjectStore.indexKV()` method.

It's better to be explicit here, so this change introduces proper validation for the indexes and also patches up this seemingly confusing issue.