### PR TITLE
feat: introducing concept of unmanaged indexes

### DIFF
--- a/internal/model/object_test.go
+++ b/internal/model/object_test.go
@@ -141,6 +141,14 @@ func TestIndexes_Validate(t *testing.T) {
 		expectedError string
 	}{
 		{
+			name: "mixed index action types",
+			indexes: Indexes{
+				{Action: IndexActionManaged},
+				{Action: IndexActionAdd},
+			},
+			expectedError: "the IndexActionManaged action cannot be used in conjunction with any other actions",
+		},
+		{
 			name: "ensure regular validation executes: without name",
 			indexes: Indexes{{
 				Type:  IndexUnique,

--- a/internal/store/index.go
+++ b/internal/store/index.go
@@ -73,6 +73,12 @@ func (s *ObjectStore) createIndexes(ctx context.Context,
 ) error {
 	indexes := object.Indexes()
 	for _, index := range indexes {
+		// Skip indexes that are meant for explicit removal only (these are
+		// only created with the model.IndexActionAdd index action).
+		if index.Action == model.IndexActionRemove {
+			continue
+		}
+
 		switch index.Type {
 		case model.IndexUnique:
 			key, value, err := s.indexKV(index, object)
@@ -154,6 +160,12 @@ func (s *ObjectStore) deleteIndexes(ctx context.Context, tx persistence.Tx,
 ) error {
 	indexes := object.Indexes()
 	for _, index := range indexes {
+		// Skip indexes that are meant for explicit addition only (these are
+		// only removed with the model.IndexActionRemove index action).
+		if index.Action == model.IndexActionAdd {
+			continue
+		}
+
 		switch index.Type {
 		case model.IndexUnique:
 			key, _, err := s.indexKV(index, object)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -201,7 +201,14 @@ func (s *ObjectStore) Upsert(ctx context.Context, object model.Object,
 					return err
 				}
 			}
-			if err := s.deleteIndexes(ctx, tx, oldObject); err != nil {
+
+			// Handle deleting explicit indexes when asked, otherwise, default to the managed behavior.
+			objectForIndexDeletions := oldObject
+			if _, ok := model.Indexes(object.Indexes()).Actions()[model.IndexActionRemove]; ok {
+				objectForIndexDeletions = object
+			}
+
+			if err := s.deleteIndexes(ctx, tx, objectForIndexDeletions); err != nil {
 				return err
 			}
 


### PR DESCRIPTION
This allows the ability to bypass the default managed index behavior that the persistence store provides, in order to explicitly set whether index(es) should be created and/or removed.

This allows the ability to add & remove foreign relations without needing to know all foreign relations that exist on the given entity.