### PR TITLE
feat: introducing foreign key management support to persistence store

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -551,12 +551,7 @@ func (s *ObjectStore) updateForeignKeysTx(
 					return err
 				}
 
-				// Ensure the foreign relation is not already created.
-				if err := s.checkIndex(gCtx, tx, index, key); err != nil {
-					return err
-				}
-
-				if err := tx.Put(gCtx, key, value); err != nil {
+				if err := tx.Insert(gCtx, key, value); err != nil {
 					return err
 				}
 			} else {


### PR DESCRIPTION
This change implements the ability to update just the foreign keys related to an object. This functionality is required for the recent consumer groups implementation.