### PR TITLE
fix: use underscore in labels

### DIFF
--- a/internal/server/kong/ws/payload.go
+++ b/internal/server/kong/ws/payload.go
@@ -120,12 +120,12 @@ func (p *Payload) configForVersion(version string) (cacheEntry, error) {
 				zap.Int("total-resource-changes", resourcesUpdated))
 			metrics.Gauge("version_compatibility_configuration_change_count",
 				int64(changeCount), metrics.Tag{
-					Key:   "kong-dp-version",
+					Key:   "kong_dp_version",
 					Value: version,
 				})
 			metrics.Gauge("version_compatibility_configuration_resource_change_count",
 				int64(resourcesUpdated), metrics.Tag{
-					Key:   "kong-dp-version",
+					Key:   "kong_dp_version",
 					Value: version,
 				})
 		}


### PR DESCRIPTION
Names for metrics & labels should use valid characters for prometheus.
See: https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels