### PR TITLE
build: pull proper version of library build script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,7 @@
 .DEFAULT_GOAL := all
 DEFAULT_BRANCH:=$(shell git remote show origin | sed -n '/HEAD branch/s/.*: //p')
 
-ATCROUTER_LIB = /tmp/lib/libatc_router.a
-DEPS = $(ATCROUTER_LIB)
-
-INSTALL_LIBS = libatc_router.so
-INSTALLED_LIBS = $(addprefix /usr/lib/,$(INSTALL_LIBS))
-
-$(ATCROUTER_LIB):
-	./scripts/build-library.sh go-atc-router/main/make-lib.sh /tmp/lib
-
-$(INSTALLED_LIBS): $(ATCROUTER_LIB)
-	sudo -En ln -s /tmp/lib/$(INSTALL_LIBS) /usr/lib
+include libraries.mk
 
 .PHONY: install-tools
 install-tools:

--- a/libraries.mk
+++ b/libraries.mk
@@ -1,0 +1,16 @@
+
+
+ATCROUTER_LIB = /tmp/lib/libatc_router.a
+
+DEPS = $(ATCROUTER_LIB)
+
+INSTALL_LIBS = libatc_router.so
+INSTALLED_LIBS = $(addprefix /usr/lib/,$(INSTALL_LIBS))
+
+
+$(ATCROUTER_LIB):
+	./scripts/build-library.sh kong/go-atc-router make-lib.sh /tmp/lib
+
+$(INSTALLED_LIBS): $(ATCROUTER_LIB)
+	sudo -En ln -s /tmp/lib/$(INSTALL_LIBS) /usr/lib
+

--- a/scripts/build-library.sh
+++ b/scripts/build-library.sh
@@ -1,6 +1,9 @@
 #!/bin/bash -e
 
-SCRIPT_REF="$1"
-DSTDIR="$2"
+MODULE_NAME="$1"
+SCRIPT_FILE="$2"
+DSTDIR="$3"
 
-curl -sSfL "https://raw.githubusercontent.com/Kong/$SCRIPT_REF" | bash -s -- "$DSTDIR"
+MODULE_VERSION=$(grep -F "$MODULE_NAME" go.mod | (read mod ver; echo "${ver##*-}"))
+
+curl -sSfL "https://raw.githubusercontent.com/$MODULE_NAME/$MODULE_VERSION/$SCRIPT_FILE" | bash -s -- "$DSTDIR"


### PR DESCRIPTION
the `build-libary.sh` script pulls the actual build script from go-atc router.

this PR makes it use the version pinned in go.mod, not only for version consistency but also makes the cache key correct, as it's built from the hash of go.mod